### PR TITLE
Fix sync support for Windows and Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:label="one_five_one_ten"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
+#include <shared_preferences_linux/shared_preferences_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) isar_flutter_libs_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "IsarFlutterLibsPlugin");
   isar_flutter_libs_plugin_register_with_registrar(isar_flutter_libs_registrar);
+  g_autoptr(FlPluginRegistrar) shared_preferences_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "SharedPreferencesLinuxPlugin");
+  shared_preferences_linux_plugin_register_with_registrar(shared_preferences_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   isar_flutter_libs
+  shared_preferences_linux
   url_launcher_linux
 )
 

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,11 +7,14 @@
 #include "generated_plugin_registrant.h"
 
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
+#include <shared_preferences_windows/shared_preferences_windows_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   IsarFlutterLibsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("IsarFlutterLibsPlugin"));
+  SharedPreferencesWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharedPreferencesWindowsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   isar_flutter_libs
+  shared_preferences_windows
   url_launcher_windows
 )
 


### PR DESCRIPTION
## Summary
- allow the Android build to reach OneDrive and price services by declaring the INTERNET permission and permitting HTTP endpoints
- register the shared_preferences plugin on Windows (and Linux) so auto-sync can read its device state without throwing MissingPluginException

## Testing
- not run (Flutter SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68c98cb14abc8326b392b850766a03d8