### PR TITLE
Improve cross-platform sync persistence and Android networking

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:label="one_five_one_ten"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/services/local_settings_service.dart
+++ b/lib/services/local_settings_service.dart
@@ -1,0 +1,162 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 一个跨平台的键值存储服务。
+///
+/// - 优先使用 [SharedPreferences]，可覆盖所有支持平台；
+/// - 若运行环境缺失对应平台插件（例如 Windows 构建时未正确生成插件注册信息），
+///   会自动回退到本地 JSON 文件存储，确保同步模块依旧可用；
+/// - 文件位于应用的 Support 目录下，文件名为 `sync_local_state.json`。
+class LocalSettingsService {
+  LocalSettingsService._();
+
+  static final LocalSettingsService instance = LocalSettingsService._();
+
+  SharedPreferences? _prefs;
+  File? _file;
+  final Map<String, dynamic> _fileCache = {};
+
+  Future<void>? _initFuture;
+  Future<void> _writeSerial = Future.value();
+
+  /// 确保底层存储已准备就绪。
+  Future<void> ensureInitialized() {
+    return _initFuture ??= _init();
+  }
+
+  Future<void> _init() async {
+    try {
+      _prefs = await SharedPreferences.getInstance();
+      return;
+    } on MissingPluginException {
+      // 插件缺失，转到文件存储。
+    } catch (_) {
+      // 任何异常都视为 SharedPreferences 不可用。
+    }
+    await _initFileStore();
+  }
+
+  Future<void> _initFileStore() async {
+    Directory dir;
+    try {
+      dir = await getApplicationSupportDirectory();
+    } catch (_) {
+      dir = await getApplicationDocumentsDirectory();
+    }
+
+    final path = '${dir.path}/sync_local_state.json';
+    _file = File(path);
+
+    if (!await _file!.exists()) {
+      await _file!.create(recursive: true);
+      return;
+    }
+
+    try {
+      final raw = await _file!.readAsString();
+      if (raw.trim().isEmpty) return;
+      final decoded = json.decode(raw);
+      if (decoded is Map) {
+        decoded.forEach((key, value) {
+          final k = key is String ? key : key.toString();
+          _fileCache[k] = value;
+        });
+      }
+    } catch (e) {
+      // 读取失败时备份原文件，避免覆盖用户数据。
+      final backupPath = '${path}.bak_${DateTime.now().millisecondsSinceEpoch}';
+      try {
+        await _file!.copy(backupPath);
+      } catch (_) {}
+      _fileCache.clear();
+      await _flushFile();
+    }
+  }
+
+  bool get _usePrefs => _prefs != null;
+
+  Future<String?> getString(String key) async {
+    await ensureInitialized();
+    if (_usePrefs) return _prefs!.getString(key);
+    final value = _fileCache[key];
+    return value is String ? value : value?.toString();
+  }
+
+  Future<bool?> getBool(String key) async {
+    await ensureInitialized();
+    if (_usePrefs) return _prefs!.getBool(key);
+    final value = _fileCache[key];
+    if (value is bool) return value;
+    if (value is String) {
+      if (value == 'true') return true;
+      if (value == 'false') return false;
+    }
+    return null;
+  }
+
+  Future<int?> getInt(String key) async {
+    await ensureInitialized();
+    if (_usePrefs) return _prefs!.getInt(key);
+    final value = _fileCache[key];
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) return int.tryParse(value);
+    return null;
+  }
+
+  Future<void> setString(String key, String value) async {
+    await ensureInitialized();
+    if (_usePrefs) {
+      await _prefs!.setString(key, value);
+    } else {
+      _fileCache[key] = value;
+      await _flushFile();
+    }
+  }
+
+  Future<void> setBool(String key, bool value) async {
+    await ensureInitialized();
+    if (_usePrefs) {
+      await _prefs!.setBool(key, value);
+    } else {
+      _fileCache[key] = value;
+      await _flushFile();
+    }
+  }
+
+  Future<void> setInt(String key, int value) async {
+    await ensureInitialized();
+    if (_usePrefs) {
+      await _prefs!.setInt(key, value);
+    } else {
+      _fileCache[key] = value;
+      await _flushFile();
+    }
+  }
+
+  Future<void> remove(String key) async {
+    await ensureInitialized();
+    if (_usePrefs) {
+      await _prefs!.remove(key);
+    } else {
+      _fileCache.remove(key);
+      await _flushFile();
+    }
+  }
+
+  Future<void> _flushFile() {
+    if (_file == null) return Future.value();
+    _writeSerial = _writeSerial.then((_) async {
+      try {
+        await _file!.writeAsString(json.encode(_fileCache), flush: true);
+      } catch (_) {
+        // 忽略写入错误，避免同步流程崩溃。
+      }
+    });
+    return _writeSerial;
+  }
+}

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -2,12 +2,12 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter/widgets.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:xxh3/xxh3.dart';
 import 'package:one_five_one_ten/services/database_service.dart';
 import 'package:one_five_one_ten/services/onedrive_service.dart';
 import 'package:one_five_one_ten/models/cloud_manifest.dart';
 import 'package:isar/isar.dart';
+import 'package:one_five_one_ten/services/local_settings_service.dart';
 
 // 引入所有需要监听的模型
 import 'package:one_five_one_ten/models/account.dart';
@@ -44,9 +44,10 @@ class SyncService with WidgetsBindingObserver {
   // 修正：start 方法，改为调用 _startDbWatchers
   Future<void> start() async {
     WidgetsBinding.instance.addObserver(this);
-    final sp = await SharedPreferences.getInstance();
-    _deviceId = sp.getString('device_id') ?? _genAndSaveDeviceId(sp);
-    _enabled = sp.getBool('auto_sync_enabled') ?? true;
+    final settings = LocalSettingsService.instance;
+    final existingId = await settings.getString('device_id');
+    _deviceId = existingId ?? await _genAndSaveDeviceId(settings);
+    _enabled = await settings.getBool('auto_sync_enabled') ?? true;
 
     if (!_enabled) return;
 
@@ -60,12 +61,12 @@ class SyncService with WidgetsBindingObserver {
   }
 
   Future<bool> _uploadSnapshot(String fileName) async {
-  final tmp = File('${Directory.systemTemp.path}/ofot_${DateTime.now().millisecondsSinceEpoch}.isar');
-  await _ds.isar.copyToFile(tmp.path);
-  final bytes = await tmp.readAsBytes();
-  await tmp.delete();
-  return await _od.uploadBackup(Uint8List.fromList(bytes), fileName);
-}
+    final tmp = File('${Directory.systemTemp.path}/ofot_${DateTime.now().millisecondsSinceEpoch}.isar');
+    await _ds.isar.copyToFile(tmp.path);
+    final bytes = await tmp.readAsBytes();
+    await tmp.delete();
+    return await _od.uploadBackup(Uint8List.fromList(bytes), fileName);
+  }
 
   // 修正：stop 方法，改为调用 _cancelDbWatchers
   Future<void> stop() async {
@@ -121,64 +122,64 @@ class SyncService with WidgetsBindingObserver {
   }
 
   Future<bool> _pullIfRemoteNewer() async {
-  final m = await _od.getManifest();
-  if (m == null) return false;
+    final m = await _od.getManifest();
+    if (m == null) return false;
 
-  final sp = await SharedPreferences.getInstance();
-  final baselineHash = sp.getString(_kLastSyncHash);
-  final baselineVer  = sp.getInt(_kLastSyncVersion) ?? 0;
+    final settings = LocalSettingsService.instance;
+    final baselineHash = await settings.getString(_kLastSyncHash);
+    final baselineVer = await settings.getInt(_kLastSyncVersion) ?? 0;
 
-  final localHash = await _calcLocalDbHash();
-  final remoteHash = m.dbHash;
-  final remoteVer  = m.version;
+    final localHash = await _calcLocalDbHash();
+    final remoteHash = m.dbHash;
+    final remoteVer = m.version;
 
-  // 情况 A：本地未改动（等于基线）且云端版本号更高 -> 安全拉取并覆盖
-  final localUnchanged = (baselineHash == null) || (localHash == baselineHash);
-  if (localUnchanged && remoteVer > baselineVer && remoteHash != localHash) {
-    final bytes = await _od.downloadBackupByName(m.fileName);
-    if (bytes == null) return false;
+    // 情况 A：本地未改动（等于基线）且云端版本号更高 -> 安全拉取并覆盖
+    final localUnchanged = (baselineHash == null) || (localHash == baselineHash);
+    if (localUnchanged && remoteVer > baselineVer && remoteHash != localHash) {
+      final bytes = await _od.downloadBackupByName(m.fileName);
+      if (bytes == null) return false;
 
-    _cancelDbWatchers();
-    final path = _ds.isar.path!;
-    await _ds.isar.close();
-    await File(path).writeAsBytes(bytes, flush: true);
-    await DatabaseService().init();
-    _startDbWatchers();
+      _cancelDbWatchers();
+      final path = _ds.isar.path!;
+      await _ds.isar.close();
+      await File(path).writeAsBytes(bytes, flush: true);
+      await DatabaseService().init();
+      _startDbWatchers();
 
-    await sp.setString(_kLastSyncHash, remoteHash);
-    await sp.setInt(_kLastSyncVersion, remoteVer);
-    return true;
-  }
+      await settings.setString(_kLastSyncHash, remoteHash);
+      await settings.setInt(_kLastSyncVersion, remoteVer);
+      return true;
+    }
 
-  // 情况 B：两端都改动（本地 != 基线 且 云端版本 > 基线）-> 冲突：不覆盖云端，上传一个本地冲突副本
-  final localChanged = (baselineHash != null) && (localHash != baselineHash);
-  final remoteAdvanced = remoteVer > baselineVer;
-  final remoteChangedFromBaseline = (remoteHash != baselineHash) || remoteAdvanced;
-  if (localChanged && remoteChangedFromBaseline) {
-    final conflictName =
-        'backup_conflict_${_deviceId}_${DateTime.now().toUtc().toIso8601String().replaceAll(':','-')}.isar';
-    await _uploadSnapshot(conflictName);
-    // 提示：可以在 UI 上给出“检测到冲突，已将本地另存为冲突快照”的 SnackBar
+    // 情况 B：两端都改动（本地 != 基线 且 云端版本 > 基线）-> 冲突：不覆盖云端，上传一个本地冲突副本
+    final localChanged = (baselineHash != null) && (localHash != baselineHash);
+    final remoteAdvanced = remoteVer > baselineVer;
+    final remoteChangedFromBaseline = (remoteHash != baselineHash) || remoteAdvanced;
+    if (localChanged && remoteChangedFromBaseline) {
+      final conflictName =
+          'backup_conflict_${_deviceId}_${DateTime.now().toUtc().toIso8601String().replaceAll(':', '-')}.isar';
+      await _uploadSnapshot(conflictName);
+      // 提示：可以在 UI 上给出“检测到冲突，已将本地另存为冲突快照”的 SnackBar
+      return false;
+    }
+
+    // 其他情况：不需要拉
     return false;
   }
 
-  // 其他情况：不需要拉
-  return false;
-}
-
   Future<void> _pushIfDirty() async {
-    final sp = await SharedPreferences.getInstance();
+    final settings = LocalSettingsService.instance;
     final m = await _od.getManifest();
-    final baselineHash = sp.getString(_kLastSyncHash);
-    final baselineVer  = sp.getInt(_kLastSyncVersion) ?? 0;
+    final baselineHash = await settings.getString(_kLastSyncHash);
+    final baselineVer = await settings.getInt(_kLastSyncVersion) ?? 0;
 
     final localHash = await _calcLocalDbHash();
 
     // 本地与云端完全一致 -> 基线同步修正即可
     if (m != null && localHash == m.dbHash) {
       if (localHash != baselineHash) {
-        await sp.setString(_kLastSyncHash, localHash);
-        await sp.setInt(_kLastSyncVersion, m.version);
+        await settings.setString(_kLastSyncHash, localHash);
+        await settings.setInt(_kLastSyncVersion, m.version);
       }
       return;
     }
@@ -186,12 +187,12 @@ class SyncService with WidgetsBindingObserver {
     // 只有在“云端仍处于基线版本（或 manifest 不存在）”时，才安全推
     final canPush = (m == null) || (m.version == baselineVer && m.dbHash == baselineHash);
     if (!canPush) {
-      // 云端比基线新，先给 _pullIfRemoteNewer 处理（含冲突检测）
+      // 云端比基线新，先交给 _pullIfRemoteNewer 处理（含冲突检测）
       return;
     }
 
     // 安全推送：上传快照 + bump manifest 版本
-    final fileName = 'backup_${DateTime.now().toUtc().toIso8601String().replaceAll(':','-')}.isar';
+    final fileName = 'backup_${DateTime.now().toUtc().toIso8601String().replaceAll(':', '-')}.isar';
     final ok = await _uploadSnapshot(fileName);
     if (!ok) return;
 
@@ -204,8 +205,8 @@ class SyncService with WidgetsBindingObserver {
     );
     await _od.putManifest(newM);
 
-    await sp.setString(_kLastSyncHash, localHash);
-    await sp.setInt(_kLastSyncVersion, newM.version);
+    await settings.setString(_kLastSyncHash, localHash);
+    await settings.setInt(_kLastSyncVersion, newM.version);
   }
 
   Future<String> _calcLocalDbHash() async {
@@ -216,32 +217,32 @@ class SyncService with WidgetsBindingObserver {
   }
 
   Future<DateTime?> _readLocalUpdatedUtc() async {
-    final sp = await SharedPreferences.getInstance();
-    final s = sp.getString('db_last_utc');
+    final settings = LocalSettingsService.instance;
+    final s = await settings.getString('db_last_utc');
     return s == null ? null : DateTime.tryParse(s)?.toUtc();
   }
 
-  String _genAndSaveDeviceId(SharedPreferences sp) {
-    final id = 'dev_${DateTime.now().millisecondsSinceEpoch}_${(1000+DateTime.now().microsecond%9000)}';
-    sp.setString('device_id', id);
+  Future<String> _genAndSaveDeviceId(LocalSettingsService settings) async {
+    final id = 'dev_${DateTime.now().millisecondsSinceEpoch}_${(1000+DateTime.now().microsecond % 9000)}';
+    await settings.setString('device_id', id);
     return id;
   }
 
   Future<void> setEnabled(bool enabled, {bool triggerSync = true}) async {
-    final sp = await SharedPreferences.getInstance();
+    final settings = LocalSettingsService.instance;
     _enabled = enabled;
-    await sp.setBool('auto_sync_enabled', enabled);
+    await settings.setBool('auto_sync_enabled', enabled);
     if (enabled) {
       await start();
-      if(triggerSync) _safeSync();
+      if (triggerSync) _safeSync();
     } else {
       await stop();
     }
   }
-  
+
   Future<bool> isEnabled() async {
-     final sp = await SharedPreferences.getInstance();
-    _enabled = sp.getBool('auto_sync_enabled') ?? true;
+    final settings = LocalSettingsService.instance;
+    _enabled = await settings.getBool('auto_sync_enabled') ?? true;
     return _enabled;
   }
 }


### PR DESCRIPTION
## Summary
- add a LocalSettingsService that falls back to a JSON file when SharedPreferences is unavailable so Windows builds can still remember sync metadata
- refactor the OneDrive and Sync services to use the new storage layer for device IDs, tokens, and sync baselines
- enable internet and clear-text HTTP traffic for release Android builds so cloud/data sync works outside of debug mode

## Testing
- flutter test *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c98cb14abc8326b392b850766a03d8