### PR TITLE
fix: correct wealth management asset subtype persistence

### DIFF
--- a/lib/models/asset.g.dart
+++ b/lib/models/asset.g.dart
@@ -295,12 +295,14 @@ const _AssetsubTypeEnumValueMap = {
   r'stock': r'stock',
   r'etf': r'etf',
   r'mutualFund': r'mutualFund',
+  r'wealthManagement': r'wealthManagement',
   r'other': r'other',
 };
 const _AssetsubTypeValueEnumMap = {
   r'stock': AssetSubType.stock,
   r'etf': AssetSubType.etf,
   r'mutualFund': AssetSubType.mutualFund,
+  r'wealthManagement': AssetSubType.wealthManagement,
   r'other': AssetSubType.other,
 };
 const _AssettrackingMethodEnumValueMap = {


### PR DESCRIPTION
## Summary
- 在 Isar 生成文件中为 AssetSubType 增加 wealthManagement 的序列化映射
- 确保价值法理财资产在保存与读取时不会被回退为股票类型

## Testing
- flutter test *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68d228dab2f48326be39c5506f09dda2