### PR TITLE
修复清仓份额资产盈亏统计为零的问题

### DIFF
--- a/lib/services/calculator_service.dart
+++ b/lib/services/calculator_service.dart
@@ -875,11 +875,15 @@ class CalculatorService {
     for (final txn in transactions) {
       switch (txn.type) {
         case TransactionType.buy:
-          totalCost += txn.amount.abs(); // 成本总是正数
+        case TransactionType.invest:
+          // "invest" 类型是旧数据中常见的份额法入金记录，这里与 buy 归为一类
+          totalCost += txn.amount.abs();
           break;
         case TransactionType.sell:
+        case TransactionType.withdraw:
         case TransactionType.dividend:
-          totalRevenue += txn.amount.abs(); // 收入也用正数记
+          // "withdraw" 同样是旧数据中常见的份额法卖出/出金记录
+          totalRevenue += txn.amount.abs();
           break;
         default:
           // 其他类型的交易在此处不计入


### PR DESCRIPTION
## Summary
- 扩展清仓份额资产收益统计，兼容历史的 invest/withdraw 交易类型

## Testing
- flutter test *(fails: Flutter 未安装在执行环境中)*

------
https://chatgpt.com/codex/tasks/task_e_68ed1561d0908326b5e0b9f5d18520f7