### PR TITLE
Fix value-based assets visibility in account pages

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,7 +46,7 @@ Future<void> main() async {
         for (var acc in allAccounts)
           if (acc.supabaseId != null) acc.supabaseId!: acc.id
       };
-      
+
       final List<PositionLike> items = [];
 
       for (final asset in allAssets) {
@@ -68,7 +68,10 @@ Future<void> main() async {
         final double rate = await fx.getRate(asset.currency, 'CNY');
         final double marketValueCNY = assetLocalValue * rate;
 
-        final int? localAccountId = accountSupabaseIdToLocalId[asset.accountSupabaseId];
+        final int? localAccountId = asset.accountLocalId ??
+            (asset.accountSupabaseId != null
+                ? accountSupabaseIdToLocalId[asset.accountSupabaseId!]
+                : null);
 
         if (marketValueCNY > 0.01 && localAccountId != null) {
           items.add(PositionLike(

--- a/lib/models/asset.dart
+++ b/lib/models/asset.dart
@@ -52,7 +52,9 @@ class Asset {
   AssetClass assetClass = AssetClass.other; 
 
   @Index()
-  String? accountSupabaseId; 
+  String? accountSupabaseId;
+
+  int? accountLocalId;
 
   @Index(type: IndexType.value, unique: true, caseSensitive: false)
   String? supabaseId; 
@@ -88,6 +90,7 @@ class Asset {
     asset.subType = _parseAssetSubType(json['sub_type']);
     asset.assetClass = _parseAssetClass(json['asset_class']);
     asset.accountSupabaseId = json['account_id'];
+    asset.accountLocalId = null;
 
     // ★★★ 新增字段的解析 ★★★
     asset.isArchived = json['is_archived'] ?? false;

--- a/lib/models/asset.g.dart
+++ b/lib/models/asset.g.dart
@@ -84,6 +84,11 @@ const AssetSchema = CollectionSchema(
       id: 12,
       name: r'updatedAt',
       type: IsarType.dateTime,
+    ),
+    r'accountLocalId': PropertySchema(
+      id: 13,
+      name: r'accountLocalId',
+      type: IsarType.long,
     )
   },
   estimateSize: _assetEstimateSize,
@@ -225,6 +230,7 @@ void _assetSerialize(
   writer.writeString(offsets[10], object.supabaseId);
   writer.writeString(offsets[11], object.trackingMethod.name);
   writer.writeDateTime(offsets[12], object.updatedAt);
+  writer.writeLong(offsets[13], object.accountLocalId);
 }
 
 Asset _assetDeserialize(
@@ -254,6 +260,7 @@ Asset _assetDeserialize(
       _AssettrackingMethodValueEnumMap[reader.readStringOrNull(offsets[11])] ??
           AssetTrackingMethod.valueBased;
   object.updatedAt = reader.readDateTimeOrNull(offsets[12]);
+  object.accountLocalId = reader.readLongOrNull(offsets[13]);
   return object;
 }
 
@@ -294,6 +301,8 @@ P _assetDeserializeProp<P>(
           AssetTrackingMethod.valueBased) as P;
     case 12:
       return (reader.readDateTimeOrNull(offset)) as P;
+    case 13:
+      return (reader.readLongOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
   }

--- a/lib/pages/add_edit_asset_page.dart
+++ b/lib/pages/add_edit_asset_page.dart
@@ -179,6 +179,7 @@ class _AddEditAssetPageState extends ConsumerState<AddEditAssetPage> {
         assetToUpdate.code = code;
         assetToUpdate.currency = currentSelectedCurrency;
         assetToUpdate.assetClass = currentSelectedAssetClass;
+        assetToUpdate.accountLocalId = widget.accountId;
         
         // (*** 2.1 关键修复：同时保存跟踪方法和子类型 ***)
         assetToUpdate.trackingMethod = currentSelectedMethod; 
@@ -206,8 +207,9 @@ class _AddEditAssetPageState extends ConsumerState<AddEditAssetPage> {
           ..trackingMethod = currentSelectedMethod // (来自 state)
           ..subType = currentSelectedSubType       // (来自 state)
           ..currency = currentSelectedCurrency
-          ..createdAt = DateTime.now() 
+          ..createdAt = DateTime.now()
           ..accountSupabaseId = parentAccount.supabaseId
+          ..accountLocalId = widget.accountId
           ..assetClass = currentSelectedAssetClass;
 
         if (latestPriceText.isNotEmpty) {

--- a/lib/pages/share_asset_detail_page.dart
+++ b/lib/pages/share_asset_detail_page.dart
@@ -77,14 +77,20 @@ class _ShareAssetDetailPageState extends ConsumerState<ShareAssetDetailPage> {
                     parentAccount = await isar.accounts.get(asset.accountLocalId!);
                   }
 
-                  if (parentAccount != null && context.mounted) {
+                  if (!context.mounted) {
+                    return;
+                  }
+
+                  if (parentAccount != null) {
+                    final accountId = parentAccount.id;
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                        builder: (_) => AddEditAssetPage(accountId: parentAccount.id, assetId: asset.id),
+                        builder: (_) => AddEditAssetPage(accountId: accountId, assetId: asset.id),
                       ),
                     );
-                  } else if (context.mounted) {
-                      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('错误：找不到父账户')));
+                  } else {
+                    ScaffoldMessenger.of(context)
+                        .showSnackBar(const SnackBar(content: Text('错误：找不到父账户')));
                   }
                 },
               ),

--- a/lib/pages/share_asset_detail_page.dart
+++ b/lib/pages/share_asset_detail_page.dart
@@ -63,13 +63,20 @@ class _ShareAssetDetailPageState extends ConsumerState<ShareAssetDetailPage> {
               IconButton(
                 icon: const Icon(Icons.edit_outlined),
                 tooltip: '编辑资产',
-                onPressed: () async { 
+                onPressed: () async {
                   final isar = DatabaseService().isar;
-                  final parentAccount = await isar.accounts.where()
-                      .filter()
-                      .supabaseIdEqualTo(asset.accountSupabaseId)
-                      .findFirst();
-                  
+                  Account? parentAccount;
+                  if (asset.accountSupabaseId != null) {
+                    parentAccount = await isar.accounts
+                        .where()
+                        .filter()
+                        .supabaseIdEqualTo(asset.accountSupabaseId)
+                        .findFirst();
+                  }
+                  if (parentAccount == null && asset.accountLocalId != null) {
+                    parentAccount = await isar.accounts.get(asset.accountLocalId!);
+                  }
+
                   if (parentAccount != null && context.mounted) {
                     Navigator.of(context).push(
                       MaterialPageRoute(

--- a/lib/pages/value_asset_detail_page.dart
+++ b/lib/pages/value_asset_detail_page.dart
@@ -67,24 +67,24 @@ class _ValueAssetDetailPageState extends ConsumerState<ValueAssetDetailPage> {
                     account = await isar.accounts.get(asset.accountLocalId!);
                   }
 
-                  if (account == null) {
-                    if (context.mounted) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('无法找到父账户，数据可能未同步。')),
-                      );
-                    }
+                  if (!context.mounted) {
                     return;
                   }
 
-                  if (context.mounted) {
+                  if (account != null) {
+                    final accountId = account.id;
                     Navigator.push(
                       context,
                       MaterialPageRoute(
                         builder: (context) => AddEditAssetPage(
-                          accountId: account.id, // (父账户的 Isar ID)
-                          assetId: asset.id,     // (当前资产的 Isar ID)
+                          accountId: accountId,
+                          assetId: asset.id,
                         ),
                       ),
+                    );
+                  } else {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('无法找到父账户，数据可能未同步。')),
                     );
                   }
                 },

--- a/lib/pages/value_asset_detail_page.dart
+++ b/lib/pages/value_asset_detail_page.dart
@@ -53,13 +53,19 @@ class _ValueAssetDetailPageState extends ConsumerState<ValueAssetDetailPage> {
                 icon: const Icon(Icons.edit),
                 tooltip: '编辑资产',
                 onPressed: () async {
-                  
+
                   final isar = DatabaseService().isar;
 
-                  final account = await isar.accounts
-                      .filter()
-                      .supabaseIdEqualTo(asset.accountSupabaseId)
-                      .findFirst();
+                  Account? account;
+                  if (asset.accountSupabaseId != null) {
+                    account = await isar.accounts
+                        .filter()
+                        .supabaseIdEqualTo(asset.accountSupabaseId)
+                        .findFirst();
+                  }
+                  if (account == null && asset.accountLocalId != null) {
+                    account = await isar.accounts.get(asset.accountLocalId!);
+                  }
 
                   if (account == null) {
                     if (context.mounted) {


### PR DESCRIPTION
## Summary
- add a local account reference on assets and backfill it so value-based holdings remain associated with their accounts even when Supabase IDs are missing
- update providers, account dialogs, and asset detail pages to use the new local linkage when filtering, counting, or editing assets
- enhance Supabase synchronization and database initialization to keep the local mapping in sync during imports, saves, and account deletion workflows

## Testing
- Not run (environment missing Flutter/Dart tooling)


------
https://chatgpt.com/codex/tasks/task_e_68ed2739c2f483268eed94e116202602