### PR TITLE
feat: implement asset mapping for allocation planner

### DIFF
--- a/lib/pages/allocation_planner_page.dart
+++ b/lib/pages/allocation_planner_page.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:isar/isar.dart';
 
 import 'package:one_five_one_ten/models/allocation_plan.dart';
 import 'package:one_five_one_ten/models/allocation_plan_item.dart';

--- a/lib/pages/allocation_planner_page.dart
+++ b/lib/pages/allocation_planner_page.dart
@@ -12,6 +12,8 @@ import 'package:one_five_one_ten/models/allocation_plan.dart';
 import 'package:one_five_one_ten/models/allocation_plan_item.dart';
 import 'package:one_five_one_ten/models/asset.dart';
 import 'package:one_five_one_ten/models/asset_bucket_map.dart';
+import 'package:one_five_one_ten/models/position_snapshot.dart';
+import 'package:one_five_one_ten/models/transaction.dart';
 import 'package:one_five_one_ten/providers/allocation_providers.dart';
 import 'package:one_five_one_ten/providers/global_providers.dart';
 import 'package:one_five_one_ten/services/allocation_service.dart';

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -7,6 +7,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:one_five_one_ten/models/account.dart';
 import 'package:one_five_one_ten/models/account_transaction.dart';
 import 'package:one_five_one_ten/models/asset.dart';
+import 'package:one_five_one_ten/models/asset_bucket_map.dart';
 import 'package:one_five_one_ten/models/position_snapshot.dart';
 import 'package:one_five_one_ten/models/transaction.dart';
 import 'package:one_five_one_ten/models/deletion.dart';
@@ -43,6 +44,7 @@ class DatabaseService {
         // 新增：资产配置
         AllocationPlanSchema,
         AllocationPlanItemSchema,
+        AssetBucketMapSchema,
       ],
       directory: dir.path,
       name: 'one_five_one_ten_db',


### PR DESCRIPTION
## Summary
- 替换资产配置规划器中“映射资产”的占位弹窗，提供可搜索、可勾选的资产映射页面
- 通过 AllocationService 新增资产映射的增删方法，并监控方案下的全部映射
- 在数据库初始化时注册 AssetBucketMap Schema，用于持久化资产映射关系

## Testing
- 未执行（当前环境缺少 Flutter/Dart 命令）

------
https://chatgpt.com/codex/tasks/task_e_6901999a83088326abfb5bc181a6cd4b