### PR TITLE
Fix Supabase account UUIDs

### DIFF
--- a/lib/pages/accounts_page.dart
+++ b/lib/pages/accounts_page.dart
@@ -362,8 +362,7 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
                         ..description = descriptionController.text.trim()
                         ..createdAt = DateTime.now()
                         ..currency = selectedCurrency
-                        ..supabaseId =
-                            DatabaseService.generateLocalSupabaseId('acc');
+                        ..supabaseId = DatabaseService.generateLocalSupabaseId();
 
                       final isar = DatabaseService().isar;
                       await isar.writeTxn(() async {

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -26,7 +26,7 @@ class DatabaseService {
   static final _random = Random();
 
   static final _uuidRegex = RegExp(
-    r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\$',
+    r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$',
   );
 
   /// 本地生成一个符合 UUID v4 规范的占位符，确保离线/未登录时也能有稳定 ID

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -25,11 +25,20 @@ class DatabaseService {
 
   static final _random = Random();
 
-  /// 本地生成一个可作为 Supabase 主键的占位符，确保离线/未登录时也能有稳定 ID
-  static String generateLocalSupabaseId(String prefix) {
-    final timestamp = DateTime.now().microsecondsSinceEpoch;
-    final salt = _random.nextInt(0xFFFFFF);
-    return '$prefix-$timestamp-$salt';
+  static final _uuidRegex = RegExp(
+    r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\$',
+  );
+
+  /// 本地生成一个符合 UUID v4 规范的占位符，确保离线/未登录时也能有稳定 ID
+  static String generateLocalSupabaseId() {
+    final bytes = List<int>.generate(16, (_) => _random.nextInt(256));
+
+    // 设置版本与变种位
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10xx
+
+    final hex = bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+    return '${hex.substring(0, 8)}-${hex.substring(8, 12)}-${hex.substring(12, 16)}-${hex.substring(16, 20)}-${hex.substring(20)}';
   }
 
   late Isar isar;
@@ -66,15 +75,73 @@ class DatabaseService {
 
   /// 兼容老数据：为缺失 supabaseId 的账户生成本地 ID，避免页面依赖非空字段时崩溃
   Future<void> _backfillLocalSupabaseIds() async {
-    final accountsWithoutId =
-        await isar.accounts.filter().supabaseIdIsNull().findAll();
-    if (accountsWithoutId.isEmpty) return;
+    final accounts = await isar.accounts.where().findAll();
+
+    final migrations = <_SupabaseIdMigration>[];
+    for (final acc in accounts) {
+      final oldId = acc.supabaseId;
+      final isValid = oldId != null && _uuidRegex.hasMatch(oldId);
+      if (isValid) continue;
+
+      final newId = generateLocalSupabaseId();
+      migrations.add(
+        _SupabaseIdMigration(
+          account: acc,
+          oldSupabaseId: oldId,
+          newSupabaseId: newId,
+        ),
+      );
+    }
+
+    if (migrations.isEmpty) return;
+
+    final relatedAssets = <String, List<Asset>>{};
+    final relatedAccountTxns = <String, List<AccountTransaction>>{};
+
+    for (final migration in migrations) {
+      final oldId = migration.oldSupabaseId;
+      if (oldId == null) continue;
+      relatedAssets[oldId] = await isar.assets
+          .where()
+          .accountSupabaseIdEqualTo(oldId)
+          .findAll();
+      relatedAccountTxns[oldId] = await isar.accountTransactions
+          .where()
+          .accountSupabaseIdEqualTo(oldId)
+          .findAll();
+    }
 
     await isar.writeTxn(() async {
-      for (final acc in accountsWithoutId) {
-        acc.supabaseId = generateLocalSupabaseId('acc');
-        await isar.accounts.put(acc);
+      for (final migration in migrations) {
+        final oldId = migration.oldSupabaseId;
+        final newId = migration.newSupabaseId;
+
+        migration.account.supabaseId = newId;
+        await isar.accounts.put(migration.account);
+
+        if (oldId != null) {
+          for (final asset in relatedAssets[oldId] ?? const <Asset>[]) {
+            asset.accountSupabaseId = newId;
+            await isar.assets.put(asset);
+          }
+          for (final txn in relatedAccountTxns[oldId] ?? const <AccountTransaction>[]) {
+            txn.accountSupabaseId = newId;
+            await isar.accountTransactions.put(txn);
+          }
+        }
       }
     });
   }
+}
+
+class _SupabaseIdMigration {
+  _SupabaseIdMigration({
+    required this.account,
+    required this.oldSupabaseId,
+    required this.newSupabaseId,
+  });
+
+  final Account account;
+  final String? oldSupabaseId;
+  final String newSupabaseId;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -963,6 +963,14 @@ packages:
       url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.1.4"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "4.5.2"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- generate valid UUIDv4 values for local Supabase IDs instead of prefixed placeholders
- migrate existing accounts with invalid Supabase IDs and update related assets and account transactions
- use the new UUID generator when creating accounts so Supabase inserts succeed

## Testing
- Not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926ae831f3883269e576a5ce902d270)