### PR TITLE
Handle Supabase IDs online and add migration helper

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,8 @@
 // 文件: lib/main.dart
 // (这是最终的、基于你现有完整代码的修复版本)
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:one_five_one_ten/pages/main_nav_page.dart'; 
+import 'package:one_five_one_ten/pages/main_nav_page.dart';
 import 'package:one_five_one_ten/services/database_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:one_five_one_ten/allocation/allocation_service.dart';
@@ -18,6 +17,7 @@ import 'package:one_five_one_ten/providers/global_providers.dart';
 
 // ▼▼▼ 1. 引入我们刚创建的修复服务 ▼▼▼
 import 'package:one_five_one_ten/services/data_fix_service.dart';
+import 'package:one_five_one_ten/services/supabase_id_migration_service.dart';
 
 
 Future<void> main() async {
@@ -35,6 +35,15 @@ Future<void> main() async {
   );
 
   await DatabaseService().init();
+
+  // ▼▼▼ 一次性：回写服务器分配的账户 Supabase ID，修复占位 UUID ▼▼▼
+  await SupabaseIdMigrationService(
+    syncService: container.read(syncServiceProvider),
+  ).runAccountIdMigration(
+    manualNameCurrencyMap: const {
+      // '账户名|币种': '服务器真实 UUID',
+    },
+  );
 
   // ▼▼▼ 2. 在此处调用一次性的数据修复脚本 ▼▼▼
   // ===============================================

--- a/lib/models/account_transaction.dart
+++ b/lib/models/account_transaction.dart
@@ -56,6 +56,8 @@ class AccountTransaction {
     accTx.date = DateTime.parse(json['date']).toLocal();
     accTx.type = TransactionType.values.byName(json['type'] ?? 'invest');
     accTx.amount = (json['amount'] as num?)?.toDouble() ?? 0.0;
+    accTx.fxRateToCny = (json['fx_rate_to_cny'] as num?)?.toDouble();
+    accTx.baseAmountCny = (json['base_amount_cny'] as num?)?.toDouble();
     
     accTx.accountSupabaseId = json['account_id']; // 关联 Account 的 UUID
     return accTx;
@@ -68,6 +70,8 @@ class AccountTransaction {
       'amount': amount,
       'account_id': accountSupabaseId, // 同步关系链接
       'created_at': createdAt.toIso8601String(),
+      'fx_rate_to_cny': fxRateToCny,
+      'base_amount_cny': baseAmountCny,
     };
   }
   // --- 新增结束 ---

--- a/lib/models/position_snapshot.dart
+++ b/lib/models/position_snapshot.dart
@@ -15,6 +15,12 @@ class PositionSnapshot {
 
   late double averageCost; // 单位成本 (Dart 内部使用的名字)
 
+  /// 快照记录时的资产币种 -> 人民币汇率（便于后续收益拆分）
+  double? fxRateToCny;
+
+  /// 快照对应的人民币成本（如有）
+  double? costBasisCny;
+
   @Index()
   String? assetSupabaseId; 
 
@@ -40,10 +46,13 @@ class PositionSnapshot {
 
     snap.date = DateTime.parse(json['date']).toLocal();
     snap.totalShares = (json['total_shares'] as num?)?.toDouble() ?? 0.0;
-    
+
     // --- 关键修复：从 'cost_basis' 读取 ---
     snap.averageCost = (json['cost_basis'] as num?)?.toDouble() ?? 0.0; // <-- 修正
     // --- 修复结束 ---
+
+    snap.fxRateToCny = (json['fx_rate_to_cny'] as num?)?.toDouble();
+    snap.costBasisCny = (json['cost_basis_cny'] as num?)?.toDouble();
     
     snap.assetSupabaseId = json['asset_id']; 
     return snap;
@@ -57,8 +66,11 @@ class PositionSnapshot {
       // --- 关键修复：写入到 'cost_basis' ---
       'cost_basis': averageCost, // <-- 修正: Dart 属性 'averageCost' 映射到数据库列 'cost_basis'
       // --- 修复结束 ---
-      
-      'asset_id': assetSupabaseId, 
+
+      'fx_rate_to_cny': fxRateToCny,
+      'cost_basis_cny': costBasisCny,
+
+      'asset_id': assetSupabaseId,
       'created_at': createdAt.toIso8601String(),
     };
   }

--- a/lib/models/transaction.dart
+++ b/lib/models/transaction.dart
@@ -23,9 +23,15 @@ class Transaction {
 
   late DateTime date;
 
-  late double amount; 
-  double? shares;   
-  double? price;    
+  late double amount;
+  double? shares;
+  double? price;
+
+  /// 资产交易发生时的资产币种 -> 人民币汇率
+  double? fxRateToCny;
+
+  /// 该笔交易折算成人民币的金额（买入为正，卖出为负）
+  double? amountCny;
 
   String? note; 
 
@@ -64,6 +70,9 @@ class Transaction {
     tx.shares = (json['quantity'] as num?)?.toDouble(); // 修正：从 'quantity' 字段读取
     tx.price = (json['price'] as num?)?.toDouble();
     tx.note = json['notes']; // 修正：从 'notes' 字段读取
+
+    tx.fxRateToCny = (json['fx_rate_to_cny'] as num?)?.toDouble();
+    tx.amountCny = (json['amount_cny'] as num?)?.toDouble();
     
     tx.assetSupabaseId = json['asset_id']; // 关联 Asset 的 UUID
     return tx;
@@ -79,6 +88,13 @@ class Transaction {
     json['asset_id'] = assetSupabaseId;
     json['created_at'] = createdAt.toIso8601String();
     json['updated_at'] = (updatedAt ?? DateTime.now()).toIso8601String();
+
+    if (fxRateToCny != null) {
+      json['fx_rate_to_cny'] = fxRateToCny;
+    }
+    if (amountCny != null) {
+      json['amount_cny'] = amountCny;
+    }
     
     // 可选字段 - 只在有值时才添加，避免null值问题
     if (shares != null) {

--- a/lib/pages/account_detail_page.dart
+++ b/lib/pages/account_detail_page.dart
@@ -182,6 +182,13 @@ class _AccountDetailPageState extends ConsumerState<AccountDetailPage> {
     final totalProfit = (performance['totalProfit'] ?? 0.0) as double;
     final profitRate = (performance['profitRate'] ?? 0.0) as double;
     final annualizedReturn = (performance['annualizedReturn'] ?? 0.0) as double;
+    final double? totalProfitCny = performance['totalProfitCny'] as double?;
+    final double? netInvestmentCny = performance['netInvestmentCny'] as double?;
+    final double? fxProfitCny = performance['fxProfitCny'] as double?;
+    final double? currentValueCny = performance['currentValueCny'] as double?;
+    final double? cnyProfitRate = (totalProfitCny != null && netInvestmentCny != null && netInvestmentCny != 0)
+        ? totalProfitCny / netInvestmentCny
+        : null;
     Color profitColor =
         totalProfit >= 0 ? Colors.red.shade400 : Colors.green.shade400;
     if (totalProfit == 0) {
@@ -240,6 +247,38 @@ class _AccountDetailPageState extends ConsumerState<AccountDetailPage> {
                   ? Colors.red.shade400
                   : Colors.green.shade400,
             ),
+            if (account.currency != 'CNY' && totalProfitCny != null) ...[
+              const Divider(height: 24),
+              _buildMetricRow(
+                context,
+                '总值（CNY）:',
+                formatCurrency(currentValueCny ?? 0, 'CNY'),
+              ),
+              _buildMetricRow(
+                context,
+                '净投入（CNY）:',
+                formatCurrency(netInvestmentCny ?? 0, 'CNY'),
+              ),
+              _buildMetricRow(
+                context,
+                '总收益（CNY）:',
+                cnyProfitRate != null
+                    ? '${formatCurrency(totalProfitCny, 'CNY')} (${percentFormat.format(cnyProfitRate)})'
+                    : formatCurrency(totalProfitCny, 'CNY'),
+                color: totalProfitCny >= 0
+                    ? Colors.red.shade400
+                    : Colors.green.shade400,
+              ),
+              if (fxProfitCny != null)
+                _buildMetricRow(
+                  context,
+                  '其中汇率影响:',
+                  formatCurrency(fxProfitCny, 'CNY'),
+                  color: fxProfitCny >= 0
+                      ? Colors.red.shade400
+                      : Colors.green.shade400,
+                ),
+            ],
             const SizedBox(height: 16),
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,

--- a/lib/pages/accounts_page.dart
+++ b/lib/pages/accounts_page.dart
@@ -62,8 +62,8 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
           ),
           IconButton(
             icon: const Icon(Icons.add),
-            tooltip: '添加账户或美元子账户',
-            onPressed: () => _showAddAccountOptions(context, ref),
+            tooltip: '添加账户',
+            onPressed: () => _showAddAccountDialog(context, ref),
           ),
         ],
       ),
@@ -248,39 +248,6 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
     );
   }
 
-  void _showAddAccountOptions(BuildContext context, WidgetRef ref) {
-    showModalBottomSheet(
-      context: context,
-      builder: (sheetContext) {
-        return SafeArea(
-          child: Wrap(
-            children: [
-              ListTile(
-                leading: const Icon(Icons.account_balance_wallet_outlined),
-                title: const Text('新增账户（默认人民币）'),
-                subtitle: const Text('适合日常人民币资金账户'),
-                onTap: () {
-                  Navigator.of(sheetContext).pop();
-                  _showAddAccountDialog(context, ref);
-                },
-              ),
-              ListTile(
-                leading: const Icon(Icons.attach_money_outlined),
-                title: const Text('新增 USD 子账户'),
-                subtitle: const Text('用于美元理财/基金，便于拆分汇率影响'),
-                onTap: () {
-                  Navigator.of(sheetContext).pop();
-                  _showAddAccountDialog(context, ref,
-                      initialCurrency: 'USD', suggestedSuffix: ' (USD)');
-                },
-              ),
-            ],
-          ),
-        );
-      },
-    );
-  }
-
   void _showAddAccountDialog(
     BuildContext context,
     WidgetRef ref, {
@@ -396,20 +363,6 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
       builder: (sheetContext) {
         return Wrap(
           children: <Widget>[
-            ListTile(
-              leading: const Icon(Icons.currency_exchange_outlined),
-              title: const Text('新增外币子账户'),
-              subtitle: const Text('为该银行新增 USD / 其他外币子账户'),
-              onTap: () {
-                Navigator.of(sheetContext).pop();
-                _showAddAccountDialog(
-                  context,
-                  ref,
-                  initialCurrency: 'USD',
-                  initialName: '${account.name} (USD)',
-                );
-              },
-            ),
             ListTile(
               leading: const Icon(Icons.edit_outlined),
               title: const Text('编辑账户'),

--- a/lib/pages/accounts_page.dart
+++ b/lib/pages/accounts_page.dart
@@ -256,7 +256,7 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
     String? initialName,
   }) {
     final TextEditingController nameController = TextEditingController(
-      text: initialName ?? (suggestedSuffix != null ? '美元账户$suggestedSuffix' : ''),
+      text: initialName ?? '',
     );
     final TextEditingController descriptionController = TextEditingController();
     String selectedCurrency = initialCurrency;

--- a/lib/pages/accounts_page.dart
+++ b/lib/pages/accounts_page.dart
@@ -160,6 +160,7 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
     final totalProfit = (performance['totalProfit'] ?? 0.0) as double;
     final profitRate = (performance['profitRate'] ?? 0.0) as double;
     final annualizedReturn = (performance['annualizedReturn'] ?? 0.0) as double;
+    final fxProfit = (performance['fxProfit'] ?? performance['fxProfitCny'] ?? 0.0) as double;
 
     Color profitColor = totalProfit >= 0 ? Colors.red.shade400 : Colors.green.shade400;
     if (totalProfit == 0) {
@@ -202,6 +203,15 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
                       const SizedBox(height: 12),
                       _buildSummaryMetric('累计收益', formatValue(totalProfit, 'currency'), context,
                           valueColor: _isAmountVisible ? profitColor : null),
+                      const SizedBox(height: 12),
+                      _buildSummaryMetric(
+                        '其中汇率影响',
+                        formatValue(fxProfit, 'currency'),
+                        context,
+                        valueColor: _isAmountVisible
+                            ? (fxProfit >= 0 ? Colors.red.shade400 : Colors.green.shade400)
+                            : null,
+                      ),
                     ],
                   ),
                 ),

--- a/lib/pages/accounts_page.dart
+++ b/lib/pages/accounts_page.dart
@@ -361,8 +361,7 @@ class _AccountsPageState extends ConsumerState<AccountsPage> {
                         ..name = name
                         ..description = descriptionController.text.trim()
                         ..createdAt = DateTime.now()
-                        ..currency = selectedCurrency
-                        ..supabaseId = DatabaseService.generateLocalSupabaseId();
+                        ..currency = selectedCurrency;
 
                       final isar = DatabaseService().isar;
                       await isar.writeTxn(() async {

--- a/lib/pages/asset_transaction_history_page.dart
+++ b/lib/pages/asset_transaction_history_page.dart
@@ -12,6 +12,7 @@ import 'package:isar/isar.dart';
 import 'package:one_five_one_ten/providers/global_providers.dart';
 import 'package:one_five_one_ten/services/supabase_sync_service.dart';
 import 'package:one_five_one_ten/utils/currency_formatter.dart';
+import 'package:one_five_one_ten/services/exchangerate_service.dart';
 
 
 // (Provider 逻辑已正确)

--- a/lib/pages/asset_transaction_history_page.dart
+++ b/lib/pages/asset_transaction_history_page.dart
@@ -118,14 +118,32 @@ class AssetTransactionHistoryPage extends ConsumerWidget {
         title = txn.type.name; icon = Icons.help_outline; color = Colors.grey;
     }
 
+    final List<Widget> subtitleLines = [
+      Text(DateFormat('yyyy-MM-dd').format(txn.date)),
+    ];
+
+    if (currencyCode != 'CNY' && txn.fxRateToCny != null) {
+      subtitleLines.add(
+        Text('汇率: ${txn.fxRateToCny!.toStringAsFixed(4)} ($currencyCode→CNY)'),
+      );
+    }
+    if (currencyCode != 'CNY' && txn.amountCny != null) {
+      subtitleLines.add(
+        Text('折算人民币金额: ${formatCurrency(txn.amountCny!, 'CNY')}'),
+      );
+    }
+
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
       child: ListTile(
         leading: Icon(icon, color: color),
         title: Text(title),
-        subtitle: Text(DateFormat('yyyy-MM-dd').format(txn.date)),
-        trailing: Text(formattedAmount, style: TextStyle(color: color, fontSize: 16, fontWeight: FontWeight.bold)), // 使用 formattedAmount
-        onTap: () => _showEditTransactionDialog(context, ref, txn, currencyCode), 
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: subtitleLines,
+        ),
+        trailing: Text(formattedAmount, style: TextStyle(color: color, fontSize: 16, fontWeight: FontWeight.bold)),
+        onTap: () => _showEditTransactionDialog(context, ref, txn, currencyCode),
         onLongPress: () => _showDeleteConfirmation(context, ref, txn),
       ),
     );

--- a/lib/pages/share_asset_detail_page.dart
+++ b/lib/pages/share_asset_detail_page.dart
@@ -625,6 +625,12 @@ class _ShareAssetDetailViewState extends ConsumerState<_ShareAssetDetailView> {
     final double totalProfit = (performance['totalProfit'] ?? 0.0) as double;
     final double profitRate = (performance['profitRate'] ?? 0.0) as double;
     final double annualizedReturn = (performance['annualizedReturn'] ?? 0.0) as double;
+    final double? totalProfitCny = performance['totalProfitCny'] as double?;
+    final double? fxProfitCny = performance['fxProfitCny'] as double?;
+    final double? totalCostCny = performance['totalCostCny'] as double?;
+    final double? cnyProfitRate = (totalProfitCny != null && totalCostCny != null && totalCostCny != 0)
+        ? totalProfitCny / totalCostCny
+        : null;
     final percentFormat =
         NumberFormat.percentPattern('zh_CN')..maximumFractionDigits = 2;
     Color profitColor =
@@ -649,13 +655,35 @@ class _ShareAssetDetailViewState extends ConsumerState<_ShareAssetDetailView> {
                color: profitColor,
             ),
             _buildMetricRow(
-              context, 
+              context,
               '年化收益率:',
               percentFormat.format(annualizedReturn),
-              color: annualizedReturn > 0 
+              color: annualizedReturn > 0
                   ? Colors.red.shade400
                   : Colors.green.shade400,
             ),
+            if (currencyCode != 'CNY' && totalProfitCny != null) ...[
+              const Divider(height: 24),
+              _buildMetricRow(
+                context,
+                '总收益（CNY）:',
+                cnyProfitRate != null
+                    ? '${formatCurrency(totalProfitCny, 'CNY')} (${percentFormat.format(cnyProfitRate)})'
+                    : formatCurrency(totalProfitCny, 'CNY'),
+                color: totalProfitCny >= 0
+                    ? Colors.red.shade400
+                    : Colors.green.shade400,
+              ),
+              if (fxProfitCny != null)
+                _buildMetricRow(
+                  context,
+                  '汇率收益（CNY）:',
+                  formatCurrency(fxProfitCny, 'CNY'),
+                  color: fxProfitCny >= 0
+                      ? Colors.red.shade400
+                      : Colors.green.shade400,
+                ),
+            ],
           ],
         ),
       ),

--- a/lib/pages/value_asset_detail_page.dart
+++ b/lib/pages/value_asset_detail_page.dart
@@ -357,6 +357,10 @@ class _ValueAssetDetailView extends ConsumerWidget {
       final double? totalProfitCny = performance['totalProfitCny'] as double?;
       final double? fxProfitCny = performance['fxProfitCny'] as double?;
       final double? assetProfitCny = performance['assetProfitCny'] as double?;
+      final double? netInvestmentCny = performance['netInvestmentCny'] as double?;
+      final double? cnyProfitRate = (totalProfitCny != null && netInvestmentCny != null && netInvestmentCny != 0)
+          ? totalProfitCny / netInvestmentCny
+          : null;
       final percentFormat =
           NumberFormat.percentPattern('zh_CN')..maximumFractionDigits = 2;
       Color profitColor =
@@ -394,7 +398,9 @@ class _ValueAssetDetailView extends ConsumerWidget {
                 buildMetricRow(
                   context,
                   '总收益（CNY）:',
-                  formatCurrency(totalProfitCny, 'CNY'),
+                  cnyProfitRate != null
+                      ? '${formatCurrency(totalProfitCny, 'CNY')} (${percentFormat.format(cnyProfitRate)})'
+                      : formatCurrency(totalProfitCny, 'CNY'),
                   color: totalProfitCny >= 0
                       ? Colors.red.shade400
                       : Colors.green.shade400,

--- a/lib/pages/value_asset_detail_page.dart
+++ b/lib/pages/value_asset_detail_page.dart
@@ -125,14 +125,34 @@ class _ValueAssetDetailPageState extends ConsumerState<ValueAssetDetailPage> {
 
   void _showAddTransactionDialog(BuildContext context, WidgetRef ref, Asset asset) {
     final amountController = TextEditingController();
+    final fxRateController = TextEditingController();
+    final cnyAmountController = TextEditingController();
     DateTime selectedDate = DateTime.now();
-    TransactionType selectedType = TransactionType.invest; 
+    TransactionType selectedType = TransactionType.invest;
+    bool rateRequested = false;
 
     showDialog(
       context: context,
       builder: (dialogContext) {
         return StatefulBuilder(
           builder: (context, setState) {
+            if (asset.currency != 'CNY' && !rateRequested) {
+              rateRequested = true;
+              ExchangeRateService()
+                  .getRate(asset.currency, 'CNY')
+                  .then((rate) {
+                if (dialogContext.mounted && fxRateController.text.isEmpty) {
+                  setState(() {
+                    fxRateController.text = rate.toStringAsFixed(4);
+                    final amount = double.tryParse(amountController.text);
+                    if (amount != null) {
+                      cnyAmountController.text =
+                          (amount * rate).toStringAsFixed(2);
+                    }
+                  });
+                }
+              });
+            }
             return AlertDialog(
               title: Text('添加 ${asset.name} 记录'),
               content: SingleChildScrollView(
@@ -161,6 +181,34 @@ class _ValueAssetDetailPageState extends ConsumerState<ValueAssetDetailPage> {
                         prefixText: getCurrencySymbol(asset.currency)
                       ),
                     ),
+                    if (asset.currency != 'CNY' && selectedType != TransactionType.updateValue) ...[
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: fxRateController,
+                        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                        decoration: const InputDecoration(
+                          labelText: '汇率（资产币种→CNY）',
+                          helperText: '默认拉取当前汇率，可手动调整',
+                        ),
+                        onChanged: (_) {
+                          final amount = double.tryParse(amountController.text);
+                          final rate = double.tryParse(fxRateController.text);
+                          if (amount != null && rate != null) {
+                            cnyAmountController.text =
+                                (amount * rate).toStringAsFixed(2);
+                          }
+                        },
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: cnyAmountController,
+                        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                        decoration: const InputDecoration(
+                          labelText: '折算人民币金额',
+                          helperText: '买入为正，卖出为负',
+                        ),
+                      ),
+                    ],
                     const SizedBox(height: 16),
                     Row(
                       children: [
@@ -203,13 +251,28 @@ class _ValueAssetDetailPageState extends ConsumerState<ValueAssetDetailPage> {
                       }
 
                       final syncService = ref.read(syncServiceProvider);
-                      
+
+                      double? fxRate;
+                      double? amountCny;
+                      if (asset.currency != 'CNY' && selectedType != TransactionType.updateValue) {
+                        fxRate = double.tryParse(fxRateController.text);
+                        amountCny = double.tryParse(cnyAmountController.text);
+                        if (fxRate == null && amountCny != null && amount > 0) {
+                          fxRate = amountCny / amount;
+                        }
+                        if (amountCny == null && fxRate != null) {
+                          amountCny = amount * fxRate;
+                        }
+                      }
+
                       final newTxn = Transaction()
                         ..type = selectedType
                         ..date = selectedDate
-                        ..amount = (selectedType == TransactionType.invest) ? -amount : amount 
+                        ..amount = (selectedType == TransactionType.invest) ? -amount : amount
                         ..createdAt = DateTime.now()
-                        ..assetSupabaseId = asset.supabaseId; 
+                        ..assetSupabaseId = asset.supabaseId
+                        ..fxRateToCny = fxRate
+                        ..amountCny = amountCny;
 
                       if (selectedType == TransactionType.updateValue) {
                         newTxn.amount = amount;
@@ -290,6 +353,9 @@ class _ValueAssetDetailView extends ConsumerWidget {
       final double totalProfit = (performance['totalProfit'] ?? 0.0) as double;
       final double profitRate = (performance['profitRate'] ?? 0.0) as double;
       final double annualizedReturn = (performance['annualizedReturn'] ?? 0.0) as double;
+      final double? totalProfitCny = performance['totalProfitCny'] as double?;
+      final double? fxProfitCny = performance['fxProfitCny'] as double?;
+      final double? assetProfitCny = performance['assetProfitCny'] as double?;
       final percentFormat =
           NumberFormat.percentPattern('zh_CN')..maximumFractionDigits = 2;
       Color profitColor =
@@ -321,6 +387,30 @@ class _ValueAssetDetailView extends ConsumerWidget {
                     ? Colors.red.shade400
                     : Colors.green.shade400,
               ),
+              if (currencyCode != 'CNY' && totalProfitCny != null) ...[
+                const SizedBox(height: 8),
+                const Divider(),
+                buildMetricRow(
+                  context,
+                  '总收益（CNY）:',
+                  formatCurrency(totalProfitCny, 'CNY'),
+                  color: totalProfitCny >= 0
+                      ? Colors.red.shade400
+                      : Colors.green.shade400,
+                ),
+                if (assetProfitCny != null)
+                  buildMetricRow(
+                    context,
+                    '标的收益（CNY）:',
+                    formatCurrency(assetProfitCny, 'CNY'),
+                  ),
+                if (fxProfitCny != null)
+                  buildMetricRow(
+                    context,
+                    '汇率收益（CNY）:',
+                    formatCurrency(fxProfitCny, 'CNY'),
+                  ),
+              ],
             ],
           ),
         ),

--- a/lib/pages/value_asset_detail_page.dart
+++ b/lib/pages/value_asset_detail_page.dart
@@ -11,6 +11,7 @@ import 'package:one_five_one_ten/services/database_service.dart';
 import 'package:one_five_one_ten/utils/currency_formatter.dart';
 import 'package:one_five_one_ten/providers/global_providers.dart';
 import 'package:one_five_one_ten/services/supabase_sync_service.dart';
+import 'package:one_five_one_ten/services/exchangerate_service.dart';
 import 'package:one_five_one_ten/pages/asset_transaction_history_page.dart';
 import 'package:isar/isar.dart';
 

--- a/lib/services/supabase_id_migration_service.dart
+++ b/lib/services/supabase_id_migration_service.dart
@@ -1,0 +1,99 @@
+import 'package:one_five_one_ten/models/account.dart';
+import 'package:one_five_one_ten/services/database_service.dart';
+import 'package:one_five_one_ten/services/supabase_sync_service.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// 一次性：修正因占位 UUID 产生的账户 ID 分裂问题
+class SupabaseIdMigrationService {
+  SupabaseIdMigrationService({required this.syncService});
+
+  final SupabaseSyncService syncService;
+
+  String _nameCurrencyKey(String name, String currency) =>
+      '${name.trim().toLowerCase()}|${currency.trim().toLowerCase()}';
+
+  String _normalizeManualKey(String raw) {
+    final parts = raw.split('|');
+    if (parts.length >= 2) {
+      return _nameCurrencyKey(parts.first, parts.sublist(1).join('|'));
+    }
+    return raw.trim().toLowerCase();
+  }
+
+  /// 运行迁移
+  ///
+  /// [manualNameCurrencyMap]：可选的手动映射，键为 `账户名|币种`（如 `现金|CNY`），
+  /// 值为 Supabase 端的真实 UUID。
+  Future<void> runAccountIdMigration({
+    Map<String, String> manualNameCurrencyMap = const {},
+  }) async {
+    if (!syncService.isLoggedIn) {
+      print('[SupabaseIdMigration] 未登录，跳过账户 ID 迁移。');
+      return;
+    }
+
+    SupabaseClient? client;
+    try {
+      client = Supabase.instance.client;
+    } catch (_) {
+      print('[SupabaseIdMigration] Supabase 未初始化，跳过。');
+      return;
+    }
+
+    final remoteResponse = await client.from('Account').select();
+    final remoteAccounts = (remoteResponse as List<dynamic>)
+        .map((json) => Account.fromSupabaseJson(json as Map<String, dynamic>))
+        .where((acc) => acc.supabaseId != null)
+        .toList();
+
+    final remoteIds = remoteAccounts.map((e) => e.supabaseId!).toSet();
+    final remoteKeyMap = <String, List<Account>>{};
+
+    for (final acc in remoteAccounts) {
+      final key = _nameCurrencyKey(acc.name, acc.currency);
+      remoteKeyMap.putIfAbsent(key, () => []).add(acc);
+    }
+
+    final manualLowerCase = <String, String>{
+      for (final entry in manualNameCurrencyMap.entries)
+        _normalizeManualKey(entry.key): entry.value,
+    };
+
+    final isar = DatabaseService().isar;
+    final accounts = await isar.accounts.where().findAll();
+
+    for (final acc in accounts) {
+      final oldId = acc.supabaseId;
+      if (oldId != null && remoteIds.contains(oldId)) continue;
+
+      final key = _nameCurrencyKey(acc.name, acc.currency);
+      final manualId = manualLowerCase[key];
+      final remoteCandidates = remoteKeyMap[key] ?? const <Account>[];
+      final hasUniqueRemote = remoteCandidates.length == 1;
+
+      String? targetId;
+      if (manualId != null && remoteIds.contains(manualId)) {
+        targetId = manualId;
+      } else if (manualId != null && !remoteIds.contains(manualId)) {
+        print(
+          '[SupabaseIdMigration] 手动映射的 ID $manualId 未在服务器找到，忽略。',
+        );
+      }
+
+      targetId ??= hasUniqueRemote ? remoteCandidates.first.supabaseId : null;
+
+      if (targetId == null || targetId == oldId) continue;
+
+      print(
+          '[SupabaseIdMigration] 回写账户 ${acc.name}(${acc.currency}) 的 ID: $oldId -> $targetId');
+      await DatabaseService().applySupabaseIdMigration(
+        account: acc,
+        oldSupabaseId: oldId,
+        newSupabaseId: targetId,
+      );
+
+      // 触发重新上行，确保关系表也更新
+      await syncService.saveAccount(acc);
+    }
+  }
+}

--- a/lib/services/supabase_id_migration_service.dart
+++ b/lib/services/supabase_id_migration_service.dart
@@ -1,6 +1,7 @@
 import 'package:one_five_one_ten/models/account.dart';
 import 'package:one_five_one_ten/services/database_service.dart';
 import 'package:one_five_one_ten/services/supabase_sync_service.dart';
+import 'package:isar/isar.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 /// 一次性：修正因占位 UUID 产生的账户 ID 分裂问题


### PR DESCRIPTION
## Summary
- backfill local Supabase IDs only when authenticated and matching remote records, removing offline UUID generation
- add a one-time Supabase ID migration service and invoke it after database init to align placeholder IDs with server values
- stop assigning placeholder IDs when creating accounts so server-issued IDs persist after sync

## Testing
- dart format (fails: dart command not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692964ab06548326b6f23a350f3ea9f5)