### PR TITLE
Show FX data in history lists

### DIFF
--- a/lib/pages/asset_transaction_history_page.dart
+++ b/lib/pages/asset_transaction_history_page.dart
@@ -125,8 +125,9 @@ class AssetTransactionHistoryPage extends ConsumerWidget {
 
     final fx = txn.fxRateToCny;
     final amountCny = txn.amountCny;
+    final isNonCnyAsset = currencyCode.toUpperCase() != 'CNY';
     final hasFx =
-        currencyCode != 'CNY' && fx != null && fx > 0 && amountCny != null;
+        isNonCnyAsset && fx != null && fx > 0 && amountCny != null;
 
     final fxTextStyle = Theme.of(context)
         .textTheme
@@ -156,6 +157,7 @@ class AssetTransactionHistoryPage extends ConsumerWidget {
           mainAxisSize: MainAxisSize.min,
           children: subtitleLines,
         ),
+        isThreeLine: hasFx,
         trailing: Text(formattedAmount, style: TextStyle(color: color, fontSize: 16, fontWeight: FontWeight.bold)),
         onTap: () => _showEditTransactionDialog(context, ref, txn, currencyCode),
         onLongPress: () => _showDeleteConfirmation(context, ref, txn),

--- a/lib/pages/asset_transaction_history_page.dart
+++ b/lib/pages/asset_transaction_history_page.dart
@@ -122,15 +122,26 @@ class AssetTransactionHistoryPage extends ConsumerWidget {
       Text(DateFormat('yyyy-MM-dd').format(txn.date)),
     ];
 
-    if (currencyCode != 'CNY' && txn.fxRateToCny != null) {
-      subtitleLines.add(
-        Text('汇率: ${txn.fxRateToCny!.toStringAsFixed(4)} ($currencyCode→CNY)'),
-      );
-    }
-    if (currencyCode != 'CNY' && txn.amountCny != null) {
-      subtitleLines.add(
-        Text('折算人民币金额: ${formatCurrency(txn.amountCny!, 'CNY')}'),
-      );
+    final fx = txn.fxRateToCny;
+    final amountCny = txn.amountCny;
+    final hasFx = currencyCode != 'CNY' && fx != null && fx > 0 && amountCny != null;
+
+    final fxTextStyle = Theme.of(context)
+        .textTheme
+        .bodySmall
+        ?.copyWith(color: Colors.grey.shade600);
+
+    if (hasFx) {
+      subtitleLines.addAll([
+        Text(
+          '汇率: ${fx.toStringAsFixed(4)} ($currencyCode→CNY)',
+          style: fxTextStyle,
+        ),
+        Text(
+          '折算人民币金额: ${formatCurrency(amountCny, 'CNY')}',
+          style: fxTextStyle,
+        ),
+      ]);
     }
 
     return Card(

--- a/lib/pages/asset_transaction_history_page.dart
+++ b/lib/pages/asset_transaction_history_page.dart
@@ -59,7 +59,8 @@ class AssetTransactionHistoryPage extends ConsumerWidget {
             itemCount: transactions.length,
             itemBuilder: (context, index) {
               final txn = transactions[index];
-              final currencyCode = asyncAsset.asData?.value?.currency ?? 'CNY';
+              final currencyCode =
+                  asyncAsset.asData?.value?.currency?.toUpperCase() ?? 'CNY';
               return _buildTransactionTile(context, ref, txn, currencyCode);
             },
           );
@@ -124,7 +125,8 @@ class AssetTransactionHistoryPage extends ConsumerWidget {
 
     final fx = txn.fxRateToCny;
     final amountCny = txn.amountCny;
-    final hasFx = currencyCode != 'CNY' && fx != null && fx > 0 && amountCny != null;
+    final hasFx =
+        currencyCode != 'CNY' && fx != null && fx > 0 && amountCny != null;
 
     final fxTextStyle = Theme.of(context)
         .textTheme
@@ -151,6 +153,7 @@ class AssetTransactionHistoryPage extends ConsumerWidget {
         title: Text(title),
         subtitle: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
           children: subtitleLines,
         ),
         trailing: Text(formattedAmount, style: TextStyle(color: color, fontSize: 16, fontWeight: FontWeight.bold)),

--- a/lib/pages/asset_transaction_history_page.dart
+++ b/lib/pages/asset_transaction_history_page.dart
@@ -124,7 +124,10 @@ class AssetTransactionHistoryPage extends ConsumerWidget {
     ];
 
     final fx = txn.fxRateToCny;
-    final amountCny = txn.amountCny;
+    final amountCny = txn.amountCny ??
+        (fx != null
+            ? txn.amount * fx
+            : null); // 旧数据可能缺少 amountCny，按汇率回推一次
     final isNonCnyAsset = currencyCode.toUpperCase() != 'CNY';
     final hasFx =
         isNonCnyAsset && fx != null && fx > 0 && amountCny != null;

--- a/lib/pages/snapshot_history_page.dart
+++ b/lib/pages/snapshot_history_page.dart
@@ -72,7 +72,10 @@ class SnapshotHistoryPage extends ConsumerWidget {
     ];
 
     final fx = snapshot.fxRateToCny;
-    final costBasisCny = snapshot.costBasisCny;
+    final costBasisCny = snapshot.costBasisCny ??
+        (fx != null
+            ? snapshot.averageCost * snapshot.totalShares * fx
+            : null); // 兼容旧记录缺少 costBasisCny 的情况
     final hasFx = currencyCode != 'CNY' && fx != null && fx > 0 && costBasisCny != null;
 
     final fxTextStyle = Theme.of(context)

--- a/lib/pages/snapshot_history_page.dart
+++ b/lib/pages/snapshot_history_page.dart
@@ -71,15 +71,26 @@ class SnapshotHistoryPage extends ConsumerWidget {
       Text('份额: ${snapshot.totalShares.toStringAsFixed(2)}'),
     ];
 
-    if (currencyCode != 'CNY' && snapshot.costBasisCny != null) {
-      subtitleLines.add(
-        Text('人民币成本: ${formatCurrency(snapshot.costBasisCny!, 'CNY')}'),
-      );
-    }
-    if (currencyCode != 'CNY' && snapshot.fxRateToCny != null) {
-      subtitleLines.add(
-        Text('成本汇率: ${snapshot.fxRateToCny!.toStringAsFixed(4)} ($currencyCode→CNY)'),
-      );
+    final fx = snapshot.fxRateToCny;
+    final costBasisCny = snapshot.costBasisCny;
+    final hasFx = currencyCode != 'CNY' && fx != null && fx > 0 && costBasisCny != null;
+
+    final fxTextStyle = Theme.of(context)
+        .textTheme
+        .bodySmall
+        ?.copyWith(color: Colors.grey.shade600);
+
+    if (hasFx) {
+      subtitleLines.addAll([
+        Text(
+          '成本汇率: ${fx.toStringAsFixed(4)} ($currencyCode→CNY)',
+          style: fxTextStyle,
+        ),
+        Text(
+          '人民币成本: ${formatCurrency(costBasisCny, 'CNY')}',
+          style: fxTextStyle,
+        ),
+      ]);
     }
 
     return Card(

--- a/lib/pages/snapshot_history_page.dart
+++ b/lib/pages/snapshot_history_page.dart
@@ -37,7 +37,7 @@ class SnapshotHistoryPage extends ConsumerWidget {
             itemBuilder: (context, index) {
               final snapshot = snapshots[index];
               final currencyCode =
-                  asyncAsset.asData?.value?.currency ?? 'CNY';
+                  asyncAsset.asData?.value?.currency?.toUpperCase() ?? 'CNY';
               return _buildSnapshotTile(
                 context,
                 ref,
@@ -100,6 +100,7 @@ class SnapshotHistoryPage extends ConsumerWidget {
         title: Text('快照日期: ${DateFormat('yyyy-MM-dd').format(snapshot.date)}'),
         subtitle: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
           children: subtitleLines,
         ),
         trailing: Text(DateFormat('yyyy-MM-dd').format(snapshot.date)),


### PR DESCRIPTION
## Summary
- display recorded FX rate and converted CNY amount in value asset transaction history items
- show snapshot FX rate and RMB cost basis in position snapshot history when available

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b1302b6c083268220c4149b38403c)