### PR TITLE
Fix allocation planner donut chart binding to local plans

### DIFF
--- a/lib/providers/allocation_providers.dart
+++ b/lib/providers/allocation_providers.dart
@@ -16,6 +16,19 @@ final allocationPlansProvider = StreamProvider<List<AllocationPlan>>((ref) {
   return svc.watchPlans();
 });
 
+/// 当前启用方案（若未明确启用，则取最新一条）
+final activeAllocationPlanProvider = StreamProvider<AllocationPlan?>((ref) {
+  final svc = ref.watch(allocationServiceProvider);
+  return svc.watchPlans().map((plans) {
+    if (plans.isEmpty) return null;
+    final active = plans.firstWhere(
+      (p) => p.isActive,
+      orElse: () => plans.first,
+    );
+    return active;
+  });
+});
+
 /// 指定方案下的所有条目（按 sortOrder 升序）
 final allocationItemsProvider = StreamProvider.family<List<AllocationPlanItem>, int>((ref, planId) {
   final svc = ref.watch(allocationServiceProvider);


### PR DESCRIPTION
## Summary
- replace the allocation planner chart to source data from the current local plan items instead of legacy mock data
- add an active allocation plan provider and wire the overview widget to live Isar streams with proper empty states
- ensure the chart refreshes automatically when plans are created, edited, or removed

## Testing
- Not run (flutter toolchain not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d5e8b1c8c83268282504067ce1138)