### PR TITLE
资产配置规划器：饼图支持目标占比 + 实际占比双环显示

### DIFF
--- a/lib/models/allocation_overview.dart
+++ b/lib/models/allocation_overview.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class AllocationChartSlice {
+  final String label;
+  final double percent;
+  final Color color;
+
+  const AllocationChartSlice({
+    required this.label,
+    required this.percent,
+    required this.color,
+  });
+}
+
+class AllocationOverview {
+  final List<AllocationChartSlice> targetSlices;
+  final List<AllocationChartSlice> actualSlices;
+
+  const AllocationOverview({
+    required this.targetSlices,
+    required this.actualSlices,
+  });
+}

--- a/lib/pages/allocation_planner_page.dart
+++ b/lib/pages/allocation_planner_page.dart
@@ -303,8 +303,16 @@ class _CurrentAllocationOverviewState
                       return Text('当前方案“${plan.name}”暂无有效条目，请添加后查看饼图。');
                     }
 
+                    final actualSliceMap = {
+                      for (final s in overview.actualSlices) s.label: s,
+                    };
+
                     final legendRows = overview.targetSlices.map((slice) {
                       final percent = slice.percent * 100;
+                      final actualPercent =
+                          actualSliceMap[slice.label]?.percent != null
+                              ? actualSliceMap[slice.label]!.percent * 100
+                              : null;
                       return Padding(
                         padding: const EdgeInsets.symmetric(vertical: 6.0),
                         child: Row(
@@ -332,14 +340,27 @@ class _CurrentAllocationOverviewState
                                     '目标占比：${percent.toStringAsFixed(1)}%（权重 ${_percentFormatter.format(slice.percent)}）',
                                     style: theme.textTheme.bodySmall,
                                   ),
+                                  Text(
+                                    '实际占比：${actualPercent?.toStringAsFixed(1) ?? '--'}%（当前持仓）',
+                                    style: theme.textTheme.bodySmall,
+                                  ),
                                 ],
                               ),
                             ),
-                            Text(
-                              '${percent.toStringAsFixed(1)}%',
-                              style: const TextStyle(
-                                fontWeight: FontWeight.bold,
-                              ),
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.end,
+                              children: [
+                                Text(
+                                  '${percent.toStringAsFixed(1)}%',
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                                Text(
+                                  '实际 ${actualPercent?.toStringAsFixed(1) ?? '--'}%',
+                                  style: theme.textTheme.bodySmall,
+                                ),
+                              ],
                             ),
                           ],
                         ),

--- a/lib/providers/allocation_providers.dart
+++ b/lib/providers/allocation_providers.dart
@@ -1,6 +1,7 @@
 // File: lib/providers/allocation_providers.dart
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:one_five_one_ten/models/allocation_overview.dart';
 import 'package:one_five_one_ten/services/allocation_service.dart';
 import 'package:one_five_one_ten/models/allocation_plan.dart';
 import 'package:one_five_one_ten/models/allocation_plan_item.dart';
@@ -33,4 +34,10 @@ final activeAllocationPlanProvider = StreamProvider<AllocationPlan?>((ref) {
 final allocationItemsProvider = StreamProvider.family<List<AllocationPlanItem>, int>((ref, planId) {
   final svc = ref.watch(allocationServiceProvider);
   return svc.watchItems(planId);
+});
+
+/// 饼图数据（当前启用方案 + 实际持仓）
+final allocationOverviewForChartProvider = StreamProvider<AllocationOverview?>((ref) {
+  final svc = ref.watch(allocationServiceProvider);
+  return svc.watchOverviewForChart();
 });

--- a/lib/services/allocation_service.dart
+++ b/lib/services/allocation_service.dart
@@ -20,6 +20,8 @@ import 'package:one_five_one_ten/models/allocation_plan.dart';
 import 'package:one_five_one_ten/models/allocation_plan_item.dart';
 import 'package:one_five_one_ten/models/asset.dart';
 import 'package:one_five_one_ten/models/asset_bucket_map.dart';
+import 'package:one_five_one_ten/models/position_snapshot.dart';
+import 'package:one_five_one_ten/models/transaction.dart';
 
 class AllocationService {
   AllocationService._(this.isar);

--- a/lib/widgets/allocation_donut_chart.dart
+++ b/lib/widgets/allocation_donut_chart.dart
@@ -2,7 +2,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:one_five_one_ten/models/allocation_overview.dart';
 
-class AllocationDonutChart extends StatelessWidget {
+class AllocationDonutChart extends StatefulWidget {
   final List<AllocationChartSlice> targetSlices;
   final List<AllocationChartSlice> actualSlices;
 
@@ -13,77 +13,205 @@ class AllocationDonutChart extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
-    const double minLabelPercent = 0.03;
-    const double centerSpace = 60.0;
+  State<AllocationDonutChart> createState() => _AllocationDonutChartState();
+}
 
+class _AllocationDonutChartState extends State<AllocationDonutChart> {
+  static const double _minLabelPercent = 0.03;
+  static const double _centerSpace = 60.0;
+  static const double _outerRadius = 110.0;
+  static const double _innerRadius = 90.0;
+
+  int? _hoveredOuterIndex;
+  int? _hoveredInnerIndex;
+
+  @override
+  Widget build(BuildContext context) {
     List<PieChartSectionData> toSections(
       List<AllocationChartSlice> slices, {
       required bool translucent,
       required double radius,
+      required int? hoveredIndex,
     }) {
-      return slices
-          .map(
-            (slice) => PieChartSectionData(
-              color: translucent ? slice.color.withOpacity(0.45) : slice.color,
-              value: slice.percent,
-              radius: radius,
-              title: slice.percent >= minLabelPercent
-                  ? '${(slice.percent * 100).toStringAsFixed(1)}%'
-                  : '',
-              titleStyle: const TextStyle(
-                color: Colors.white,
-                fontWeight: FontWeight.bold,
-                fontSize: 12,
-              ),
-            ),
-          )
-          .toList();
+      return slices.asMap().entries.map((entry) {
+        final index = entry.key;
+        final slice = entry.value;
+        final isHovered = hoveredIndex == index;
+        return PieChartSectionData(
+          color: translucent ? slice.color.withOpacity(0.45) : slice.color,
+          value: slice.percent,
+          radius: isHovered ? radius + 6 : radius,
+          showTitle: true,
+          title: isHovered || slice.percent >= _minLabelPercent
+              ? '${(slice.percent * 100).toStringAsFixed(1)}%'
+              : '',
+          titleStyle: TextStyle(
+            color: Colors.white,
+            fontWeight: isHovered ? FontWeight.w800 : FontWeight.bold,
+            fontSize: isHovered ? 13 : 12,
+          ),
+          borderSide: isHovered
+              ? BorderSide(
+                  color: Colors.white.withOpacity(0.8),
+                  width: 1.4,
+                )
+              : BorderSide.none,
+        );
+      }).toList();
     }
 
-    return Stack(
-      alignment: Alignment.center,
+    AllocationChartSlice? _sliceByLabel(
+      List<AllocationChartSlice> slices,
+      String label,
+    ) {
+      for (final slice in slices) {
+        if (slice.label == label) return slice;
+      }
+      return null;
+    }
+
+    String _buildCenterTitle() {
+      String? label;
+      AllocationChartSlice? target;
+      AllocationChartSlice? actual;
+
+      if (_hoveredOuterIndex != null &&
+          _hoveredOuterIndex! < widget.targetSlices.length) {
+        target = widget.targetSlices[_hoveredOuterIndex!];
+        label = target.label;
+        actual = _sliceByLabel(widget.actualSlices, label);
+      } else if (_hoveredInnerIndex != null &&
+          _hoveredInnerIndex! < widget.actualSlices.length) {
+        actual = widget.actualSlices[_hoveredInnerIndex!];
+        label = actual.label;
+        target = _sliceByLabel(widget.targetSlices, label);
+      }
+
+      if (label != null) {
+        final targetText = target != null
+            ? '目标 ${(target.percent * 100).toStringAsFixed(1)}%'
+            : '目标 --';
+        final actualText = actual != null
+            ? '实际 ${(actual.percent * 100).toStringAsFixed(1)}%'
+            : '实际 --';
+        return '$label\n$targetText / $actualText';
+      }
+
+      return widget.actualSlices.isEmpty
+          ? '资产配置\n外圈：目标 / 内圈：实际（暂无数据）'
+          : '资产配置\n外圈：目标 / 内圈：实际';
+    }
+
+    Widget _buildLegendPill({
+      required Color color,
+      required String text,
+    }) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 12,
+            height: 12,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+              border: Border.all(color: Colors.white.withOpacity(0.6)),
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(text, style: Theme.of(context).textTheme.bodySmall),
+        ],
+      );
+    }
+
+    Widget _buildChartLayer({
+      required bool translucent,
+      required double radius,
+      required int? hoveredIndex,
+      required void Function(int? index) onHoverChanged,
+      required List<AllocationChartSlice> slices,
+    }) {
+      if (slices.isEmpty) return const SizedBox.shrink();
+      return PieChart(
+        PieChartData(
+          pieTouchData: PieTouchData(
+            enabled: true,
+            touchCallback: (event, response) {
+              if (!event.isInterestedForInteractions ||
+                  response?.touchedSection == null) {
+                onHoverChanged(null);
+                return;
+              }
+              onHoverChanged(response!.touchedSection!.touchedSectionIndex);
+            },
+          ),
+          sectionsSpace: translucent ? 2 : 1,
+          centerSpaceRadius: _centerSpace,
+          sections: toSections(
+            slices,
+            translucent: translucent,
+            radius: radius,
+            hoveredIndex: hoveredIndex,
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
       children: [
-        if (targetSlices.isNotEmpty)
-          PieChart(
-            PieChartData(
-              sectionsSpace: 2,
-              centerSpaceRadius: centerSpace,
-              sections: toSections(
-                targetSlices,
-                translucent: true,
-                radius: 110,
-              ),
+        SizedBox(
+          height: 210,
+          child: MouseRegion(
+            onExit: (_) {
+              setState(() {
+                _hoveredInnerIndex = null;
+                _hoveredOuterIndex = null;
+              });
+            },
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                _buildChartLayer(
+                  translucent: true,
+                  radius: _outerRadius,
+                  hoveredIndex: _hoveredOuterIndex,
+                  onHoverChanged: (index) {
+                    setState(() => _hoveredOuterIndex = index);
+                  },
+                  slices: widget.targetSlices,
+                ),
+                _buildChartLayer(
+                  translucent: false,
+                  radius: _innerRadius,
+                  hoveredIndex: _hoveredInnerIndex,
+                  onHoverChanged: (index) {
+                    setState(() => _hoveredInnerIndex = index);
+                  },
+                  slices: widget.actualSlices,
+                ),
+                Text(
+                  _buildCenterTitle(),
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
             ),
           ),
-        if (actualSlices.isNotEmpty)
-          PieChart(
-            PieChartData(
-              sectionsSpace: 1,
-              centerSpaceRadius: centerSpace,
-              sections: toSections(
-                actualSlices,
-                translucent: false,
-                radius: 90,
-              ),
-            ),
-          ),
-        Column(
-          mainAxisSize: MainAxisSize.min,
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 16,
+          runSpacing: 8,
+          alignment: WrapAlignment.center,
           children: [
-            Text(
-              '资产配置',
-              style: Theme.of(context).textTheme.bodyMedium,
+            _buildLegendPill(
+              color: Colors.grey.withOpacity(0.35),
+              text: '外圈：目标占比（方案）',
             ),
-            const SizedBox(height: 4),
-            Text(
-              actualSlices.isEmpty
-                  ? '外圈：目标 / 内圈：实际（暂无数据）'
-                  : '外圈：目标 / 内圈：实际',
-              style: Theme.of(context)
-                  .textTheme
-                  .bodySmall
-                  ?.copyWith(color: Colors.grey[700]),
+            _buildLegendPill(
+              color: Colors.grey.shade600,
+              text: '内圈：实际占比（当前持仓）',
             ),
           ],
         ),

--- a/lib/widgets/allocation_donut_chart.dart
+++ b/lib/widgets/allocation_donut_chart.dart
@@ -1,0 +1,93 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:one_five_one_ten/models/allocation_overview.dart';
+
+class AllocationDonutChart extends StatelessWidget {
+  final List<AllocationChartSlice> targetSlices;
+  final List<AllocationChartSlice> actualSlices;
+
+  const AllocationDonutChart({
+    super.key,
+    required this.targetSlices,
+    required this.actualSlices,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const double minLabelPercent = 0.03;
+    const double centerSpace = 60.0;
+
+    List<PieChartSectionData> toSections(
+      List<AllocationChartSlice> slices, {
+      required bool translucent,
+      required double radius,
+    }) {
+      return slices
+          .map(
+            (slice) => PieChartSectionData(
+              color: translucent ? slice.color.withOpacity(0.45) : slice.color,
+              value: slice.percent,
+              radius: radius,
+              title: slice.percent >= minLabelPercent
+                  ? '${(slice.percent * 100).toStringAsFixed(1)}%'
+                  : '',
+              titleStyle: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+                fontSize: 12,
+              ),
+            ),
+          )
+          .toList();
+    }
+
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        if (targetSlices.isNotEmpty)
+          PieChart(
+            PieChartData(
+              sectionsSpace: 2,
+              centerSpaceRadius: centerSpace,
+              sections: toSections(
+                targetSlices,
+                translucent: true,
+                radius: 110,
+              ),
+            ),
+          ),
+        if (actualSlices.isNotEmpty)
+          PieChart(
+            PieChartData(
+              sectionsSpace: 1,
+              centerSpaceRadius: centerSpace,
+              sections: toSections(
+                actualSlices,
+                translucent: false,
+                radius: 90,
+              ),
+            ),
+          ),
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '资产配置',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              actualSlices.isEmpty
+                  ? '外圈：目标 / 内圈：实际（暂无数据）'
+                  : '外圈：目标 / 内圈：实际',
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(color: Colors.grey[700]),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/allocation_donut_chart.dart
+++ b/lib/widgets/allocation_donut_chart.dart
@@ -137,12 +137,16 @@ class _AllocationDonutChartState extends State<AllocationDonutChart> {
           pieTouchData: PieTouchData(
             enabled: true,
             touchCallback: (event, response) {
+              final touchedIndex =
+                  response?.touchedSection?.touchedSectionIndex;
               if (!event.isInterestedForInteractions ||
-                  response?.touchedSection == null) {
+                  touchedIndex == null ||
+                  touchedIndex < 0 ||
+                  touchedIndex >= slices.length) {
                 onHoverChanged(null);
                 return;
               }
-              onHoverChanged(response!.touchedSection!.touchedSectionIndex);
+              onHoverChanged(touchedIndex);
             },
           ),
           sectionsSpace: translucent ? 2 : 1,


### PR DESCRIPTION
## Summary
- 新增 AllocationOverview 结构，服务层同时汇总当前启用方案目标权重与实际持仓占比并保持颜色映射一致
- 增加双环 AllocationDonutChart 组件，外圈展示目标占比、内圈展示实际占比，并提供中心说明文字
- 规划器页面改用新的概览与组件渲染饼图，保留现有图例与偏离展示逻辑

## Testing
- 未运行（CI/本地环境缺少 flutter 命令）


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da4a129748326a45666b0fef3e2d1)