### PR TITLE
Standardize snapshot unit cost display

### DIFF
--- a/lib/utils/number_formatter.dart
+++ b/lib/utils/number_formatter.dart
@@ -1,0 +1,8 @@
+import 'package:one_five_one_ten/models/asset.dart';
+
+String formatSnapshotUnitCost(double cost, Asset asset) {
+  if (asset.trackingMethod == AssetTrackingMethod.shareBased) {
+    return cost.toStringAsFixed(3);
+  }
+  return cost.toStringAsFixed(4);
+}

--- a/lib/utils/number_formatter.dart
+++ b/lib/utils/number_formatter.dart
@@ -1,8 +1,14 @@
 import 'package:one_five_one_ten/models/asset.dart';
 
 String formatSnapshotUnitCost(double cost, Asset asset) {
-  if (asset.trackingMethod == AssetTrackingMethod.shareBased) {
+  if (asset.subType == AssetSubType.etf) {
     return cost.toStringAsFixed(3);
   }
-  return cost.toStringAsFixed(4);
+
+  if (asset.subType == AssetSubType.mutualFund) {
+    return cost.toStringAsFixed(4);
+  }
+
+  // 其他资产类型维持默认行为（当前为 3 位小数）
+  return cost.toStringAsFixed(3);
 }


### PR DESCRIPTION
## Summary
- add a shared snapshot unit cost formatter that honors asset tracking method
- update snapshot history view to fetch asset details and render unit cost with correct precision

## Testing
- dart format lib/pages/snapshot_history_page.dart lib/utils/number_formatter.dart *(fails: dart/flutter not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69313c14490883268af84ad0146960f6)