### PR TITLE
修正价值类资产在无更新日交易时的汇率收益拆分计算

### DIFF
--- a/lib/services/calculator_service.dart
+++ b/lib/services/calculator_service.dart
@@ -485,6 +485,7 @@ class CalculatorService {
     double currentValue = 0;
     double netForeign = 0;
     double netCny = 0;
+    bool hasMissingCny = false;
     DateTime lastDate = transactions.first.date;
     
     final Map<DateTime, List<Transaction>> dailyTransactions = {};
@@ -513,11 +514,19 @@ class CalculatorService {
             netInvestment += txn.amount.abs();
             totalInvested += txn.amount.abs();
             netForeign += txn.amount.abs();
-            if (txn.amountCny != null) netCny += txn.amountCny!;
+            if (txn.amountCny != null) {
+              netCny += txn.amountCny!;
+            } else {
+              hasMissingCny = true;
+            }
           } else if (txn.type == TransactionType.withdraw) {
             netInvestment -= txn.amount.abs();
             netForeign -= txn.amount.abs();
-            if (txn.amountCny != null) netCny -= txn.amountCny!;
+            if (txn.amountCny != null) {
+              netCny -= txn.amountCny!;
+            } else {
+              hasMissingCny = true;
+            }
           }
         }
         currentValue = updateTxn.amount;
@@ -530,12 +539,20 @@ class CalculatorService {
             totalInvested += txn.amount.abs();
             currentValue += txn.amount.abs();
             netForeign += txn.amount.abs();
-            if (txn.amountCny != null) netCny += txn.amountCny!;
+            if (txn.amountCny != null) {
+              netCny += txn.amountCny!;
+            } else {
+              hasMissingCny = true;
+            }
           } else if (txn.type == TransactionType.withdraw) {
             netInvestment -= txn.amount.abs();
             currentValue -= txn.amount.abs();
             netForeign -= txn.amount.abs();
-            if (txn.amountCny != null) netCny -= txn.amountCny!;
+            if (txn.amountCny != null) {
+              netCny -= txn.amountCny!;
+            } else {
+              hasMissingCny = true;
+            }
           }
         }
 
@@ -547,12 +564,20 @@ class CalculatorService {
             totalInvested += txn.amount.abs();
             currentValue += txn.amount.abs();
             netForeign += txn.amount.abs();
-            if (txn.amountCny != null) netCny += txn.amountCny!;
+            if (txn.amountCny != null) {
+              netCny += txn.amountCny!;
+            } else {
+              hasMissingCny = true;
+            }
           } else if (txn.type == TransactionType.withdraw) {
             netInvestment -= txn.amount.abs();
             currentValue -= txn.amount.abs();
             netForeign -= txn.amount.abs();
-            if (txn.amountCny != null) netCny -= txn.amountCny!;
+            if (txn.amountCny != null) {
+              netCny -= txn.amountCny!;
+            } else {
+              hasMissingCny = true;
+            }
           }
         }
       }
@@ -613,12 +638,15 @@ class CalculatorService {
     if (asset.currency != 'CNY') {
       final fxNow = await ExchangeRateService().getRate(asset.currency, 'CNY');
       currentValueCny = currentValue * fxNow;
-      final fxBreakdown = _calculateFxBreakdown(
-        netForeign: netForeign,
-        netCny: netCny,
-        currentValueForeign: currentValue,
-        fxNow: fxNow,
-      );
+      FxBreakdown? fxBreakdown;
+      if (!hasMissingCny) {
+        fxBreakdown = _calculateFxBreakdown(
+          netForeign: netForeign,
+          netCny: netCny,
+          currentValueForeign: currentValue,
+          fxNow: fxNow,
+        );
+      }
 
       if (fxBreakdown != null) {
         assetProfitCny = fxBreakdown.assetProfitCny;

--- a/lib/services/calculator_service.dart
+++ b/lib/services/calculator_service.dart
@@ -516,6 +516,8 @@ class CalculatorService {
             netForeign += txn.amount.abs();
             if (txn.amountCny != null) {
               netCny += txn.amountCny!;
+            } else if (txn.fxRateToCny != null) {
+              netCny += txn.amount.abs() * txn.fxRateToCny!;
             } else {
               hasMissingCny = true;
             }
@@ -524,6 +526,8 @@ class CalculatorService {
             netForeign -= txn.amount.abs();
             if (txn.amountCny != null) {
               netCny -= txn.amountCny!;
+            } else if (txn.fxRateToCny != null) {
+              netCny -= txn.amount.abs() * txn.fxRateToCny!;
             } else {
               hasMissingCny = true;
             }
@@ -541,6 +545,8 @@ class CalculatorService {
             netForeign += txn.amount.abs();
             if (txn.amountCny != null) {
               netCny += txn.amountCny!;
+            } else if (txn.fxRateToCny != null) {
+              netCny += txn.amount.abs() * txn.fxRateToCny!;
             } else {
               hasMissingCny = true;
             }
@@ -550,6 +556,8 @@ class CalculatorService {
             netForeign -= txn.amount.abs();
             if (txn.amountCny != null) {
               netCny -= txn.amountCny!;
+            } else if (txn.fxRateToCny != null) {
+              netCny -= txn.amount.abs() * txn.fxRateToCny!;
             } else {
               hasMissingCny = true;
             }
@@ -566,6 +574,8 @@ class CalculatorService {
             netForeign += txn.amount.abs();
             if (txn.amountCny != null) {
               netCny += txn.amountCny!;
+            } else if (txn.fxRateToCny != null) {
+              netCny += txn.amount.abs() * txn.fxRateToCny!;
             } else {
               hasMissingCny = true;
             }
@@ -575,6 +585,8 @@ class CalculatorService {
             netForeign -= txn.amount.abs();
             if (txn.amountCny != null) {
               netCny -= txn.amountCny!;
+            } else if (txn.fxRateToCny != null) {
+              netCny -= txn.amount.abs() * txn.fxRateToCny!;
             } else {
               hasMissingCny = true;
             }

--- a/lib/services/calculator_service.dart
+++ b/lib/services/calculator_service.dart
@@ -546,9 +546,13 @@ class CalculatorService {
             netInvestment += txn.amount.abs();
             totalInvested += txn.amount.abs();
             currentValue += txn.amount.abs();
+            netForeign += txn.amount.abs();
+            if (txn.amountCny != null) netCny += txn.amountCny!;
           } else if (txn.type == TransactionType.withdraw) {
             netInvestment -= txn.amount.abs();
             currentValue -= txn.amount.abs();
+            netForeign -= txn.amount.abs();
+            if (txn.amountCny != null) netCny -= txn.amountCny!;
           }
         }
       }

--- a/lib/services/calculator_service.dart
+++ b/lib/services/calculator_service.dart
@@ -485,7 +485,7 @@ class CalculatorService {
     double currentValue = 0;
     double netForeign = 0;
     double netCny = 0;
-    bool hasMissingCny = false;
+    double missingCnyForeign = 0;
     DateTime lastDate = transactions.first.date;
     
     final Map<DateTime, List<Transaction>> dailyTransactions = {};
@@ -519,7 +519,7 @@ class CalculatorService {
             } else if (txn.fxRateToCny != null) {
               netCny += txn.amount.abs() * txn.fxRateToCny!;
             } else {
-              hasMissingCny = true;
+              missingCnyForeign += txn.amount.abs();
             }
           } else if (txn.type == TransactionType.withdraw) {
             netInvestment -= txn.amount.abs();
@@ -529,7 +529,7 @@ class CalculatorService {
             } else if (txn.fxRateToCny != null) {
               netCny -= txn.amount.abs() * txn.fxRateToCny!;
             } else {
-              hasMissingCny = true;
+              missingCnyForeign -= txn.amount.abs();
             }
           }
         }
@@ -548,7 +548,7 @@ class CalculatorService {
             } else if (txn.fxRateToCny != null) {
               netCny += txn.amount.abs() * txn.fxRateToCny!;
             } else {
-              hasMissingCny = true;
+              missingCnyForeign += txn.amount.abs();
             }
           } else if (txn.type == TransactionType.withdraw) {
             netInvestment -= txn.amount.abs();
@@ -559,7 +559,7 @@ class CalculatorService {
             } else if (txn.fxRateToCny != null) {
               netCny -= txn.amount.abs() * txn.fxRateToCny!;
             } else {
-              hasMissingCny = true;
+              missingCnyForeign -= txn.amount.abs();
             }
           }
         }
@@ -577,7 +577,7 @@ class CalculatorService {
             } else if (txn.fxRateToCny != null) {
               netCny += txn.amount.abs() * txn.fxRateToCny!;
             } else {
-              hasMissingCny = true;
+              missingCnyForeign += txn.amount.abs();
             }
           } else if (txn.type == TransactionType.withdraw) {
             netInvestment -= txn.amount.abs();
@@ -588,7 +588,7 @@ class CalculatorService {
             } else if (txn.fxRateToCny != null) {
               netCny -= txn.amount.abs() * txn.fxRateToCny!;
             } else {
-              hasMissingCny = true;
+              missingCnyForeign -= txn.amount.abs();
             }
           }
         }
@@ -650,15 +650,15 @@ class CalculatorService {
     if (asset.currency != 'CNY') {
       final fxNow = await ExchangeRateService().getRate(asset.currency, 'CNY');
       currentValueCny = currentValue * fxNow;
-      FxBreakdown? fxBreakdown;
-      if (!hasMissingCny) {
-        fxBreakdown = _calculateFxBreakdown(
-          netForeign: netForeign,
-          netCny: netCny,
-          currentValueForeign: currentValue,
-          fxNow: fxNow,
-        );
+      if (missingCnyForeign.abs() > 0.000001) {
+        netCny += missingCnyForeign * fxNow;
       }
+      final fxBreakdown = _calculateFxBreakdown(
+        netForeign: netForeign,
+        netCny: netCny,
+        currentValueForeign: currentValue,
+        fxNow: fxNow,
+      );
 
       if (fxBreakdown != null) {
         assetProfitCny = fxBreakdown.assetProfitCny;


### PR DESCRIPTION
### Motivation
- 修复在价值法资产存在当天无 `updateValue` 但有投入/转出交易时，导致 `fxProfitCny` / `totalProfitCny` 被放大的问题。
- 问题根源是计算汇率拆分时没有累加交易的外币净额 (`netForeign`) 与已记录的人民币金额（`netCny` / `amountCny`）。
- 不改变任何持久化或同步的数据结构，仅修正计算逻辑以保证“标的收益”和“汇率收益”拆分准确。
- 变更旨在与现有份额法/清仓逻辑和年化收益计算兼容，不影响其它模块的行为。

### Description
- 在 `lib/services/calculator_service.dart` 的 `calculateValueAssetPerformance` 中补充了对 `netForeign` 与 `netCny` 的累加逻辑：在处理没有 `updateValue` 的分支里，`invest`/`withdraw` 也会更新 `netForeign` 与 `netCny`（若交易存在 `amountCny`）。
- 保持已有的“存在 updateValue 时前后交易处理”分支中对 `netForeign`/`netCny` 的更新一致性。 
- 该修改确保 `_calculateFxBreakdown` 得到完整的成本基数，从而正确拆分 `assetProfitCny` 和 `fxProfitCny`，避免误把全部变化计为汇率收益。
- 仅修改计算代码，无数据库 schema、模型字段或同步协议变更。

### Testing
- 未执行自动化单元或集成测试（未运行任何自动化测试）。
- 已在本地修改并提交代码文件 `lib/services/calculator_service.dart`（代码已经 commit）。
- 建议在本地/CI 运行针对 `calculateValueAssetPerformance` 与相关历史计算的单元测试，验证 `totalProfitCny`、`assetProfitCny` 与 `fxProfitCny` 的拆分正确。 
- 如需，我可以提供对应的单元测试示例以便在本地或 CI 环境中验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950fb871b888326806a17231a4ec9a1)