### PR TITLE
按资产聚合账户绩效并汇总 fxProfitCny，调整账户 CNY 显示逻辑

### DIFF
--- a/lib/pages/account_detail_page.dart
+++ b/lib/pages/account_detail_page.dart
@@ -247,7 +247,7 @@ class _AccountDetailPageState extends ConsumerState<AccountDetailPage> {
                   ? Colors.red.shade400
                   : Colors.green.shade400,
             ),
-            if (account.currency != 'CNY' && totalProfitCny != null) ...[
+            if (fxProfitCny != null) ...[
               const Divider(height: 24),
               _buildMetricRow(
                 context,
@@ -263,9 +263,9 @@ class _AccountDetailPageState extends ConsumerState<AccountDetailPage> {
                 context,
                 '总收益（CNY）:',
                 cnyProfitRate != null
-                    ? '${formatCurrency(totalProfitCny, 'CNY')} (${percentFormat.format(cnyProfitRate)})'
-                    : formatCurrency(totalProfitCny, 'CNY'),
-                color: totalProfitCny >= 0
+                    ? '${formatCurrency(totalProfitCny ?? 0, 'CNY')} (${percentFormat.format(cnyProfitRate)})'
+                    : formatCurrency(totalProfitCny ?? 0, 'CNY'),
+                color: (totalProfitCny ?? 0) >= 0
                     ? Colors.red.shade400
                     : Colors.green.shade400,
               ),

--- a/lib/services/calculator_service.dart
+++ b/lib/services/calculator_service.dart
@@ -102,19 +102,15 @@ class CalculatorService {
         .accountSupabaseIdEqualTo(account.supabaseId)
         .sortByDate()
         .findAll();
-    final assets = await _isar.assets
-        .filter()
-        .accountSupabaseIdEqualTo(account.supabaseId)
-        .findAll();
     final historyPoints = _buildAccountHistoryPoints(originalTransactions);
     if (historyPoints.isEmpty) {
       return {'currentValue': 0.0, 'netInvestment': 0.0, 'totalProfit': 0.0, 'profitRate': 0.0, 'annualizedReturn': 0.0};
     }
-    double currentValue = historyPoints.last.value;
-    double netInvestment = historyPoints.last.netInvestment;
+    final double currentValue = historyPoints.last.value;
+    final double netInvestment = historyPoints.last.netInvestment;
     final double totalInvested = historyPoints.last.totalInvested;
-    double totalProfit = currentValue - netInvestment;
-    double profitRate = totalInvested == 0 ? 0 : totalProfit / totalInvested;
+    final double totalProfit = currentValue - netInvestment;
+    final double profitRate = totalInvested == 0 ? 0 : totalProfit / totalInvested;
     double annualizedReturn = 0.0;
     final xirrCashflows = <double>[];
     final xirrDates = <DateTime>[];
@@ -170,90 +166,29 @@ class CalculatorService {
       }
 
       totalProfitCny = currentValueCny - recordedNetInvestmentCNY;
-      final baseProfitCny = (currentValue - netInvestment) * rate;
-      fxProfitCny = totalProfitCny - baseProfitCny;
       netInvestmentCny = recordedNetInvestmentCNY;
     }
 
-    double aggregatedCurrentValue = 0.0;
-    double aggregatedNetInvestment = 0.0;
-    double aggregatedTotalProfit = 0.0;
-    double aggregatedCurrentValueCny = 0.0;
-    double aggregatedNetInvestmentCny = 0.0;
-    double aggregatedTotalProfitCny = 0.0;
-    double aggregatedFxProfitCny = 0.0;
-    bool hasFxProfitCny = false;
-    bool hasCnyAggregation = false;
-
-    for (final asset in assets) {
-      Map<String, dynamic> performance;
-      double assetCurrentValue = 0.0;
-      double assetNetInvestment = 0.0;
-      double assetTotalProfit = 0.0;
-      double? assetCurrentValueCny;
-      double? assetNetInvestmentCny;
-      double? assetTotalProfitCny;
-
-      if (asset.trackingMethod == AssetTrackingMethod.shareBased) {
-        performance = await calculateShareAssetPerformance(asset);
-        assetCurrentValue = (performance['marketValue'] ?? 0.0) as double;
-        assetNetInvestment = (performance['totalCost'] ?? 0.0) as double;
-        assetTotalProfit = (performance['totalProfit'] ?? 0.0) as double;
-        assetCurrentValueCny = performance['marketValueCny'] as double?;
-        assetNetInvestmentCny = performance['totalCostCny'] as double?;
-        assetTotalProfitCny = performance['totalProfitCny'] as double?;
-      } else {
-        performance = await calculateValueAssetPerformance(asset);
-        assetCurrentValue = (performance['currentValue'] ?? 0.0) as double;
-        assetNetInvestment = (performance['netInvestment'] ?? 0.0) as double;
-        assetTotalProfit = (performance['totalProfit'] ?? 0.0) as double;
-        assetCurrentValueCny = performance['currentValueCny'] as double?;
-        assetNetInvestmentCny = performance['netInvestmentCny'] as double?;
-        assetTotalProfitCny = performance['totalProfitCny'] as double?;
+    if (account.currency != 'CNY') {
+      final assets = await _isar.assets
+          .filter()
+          .accountSupabaseIdEqualTo(account.supabaseId)
+          .findAll();
+      double aggregatedFxProfitCny = 0.0;
+      bool hasFxProfitCny = false;
+      for (final asset in assets) {
+        final Map<String, dynamic> performance =
+            asset.trackingMethod == AssetTrackingMethod.shareBased
+                ? await calculateShareAssetPerformance(asset)
+                : await calculateValueAssetPerformance(asset);
+        final assetFxProfitCny = performance['fxProfitCny'] as double?;
+        if (assetFxProfitCny != null) {
+          aggregatedFxProfitCny += assetFxProfitCny;
+          hasFxProfitCny = true;
+        }
       }
-
-      aggregatedCurrentValue += assetCurrentValue;
-      aggregatedNetInvestment += assetNetInvestment;
-      aggregatedTotalProfit += assetTotalProfit;
-
-      final assetFxProfitCny = performance['fxProfitCny'] as double?;
-      if (assetFxProfitCny != null) {
-        aggregatedFxProfitCny += assetFxProfitCny;
-        hasFxProfitCny = true;
-      }
-
-      if (asset.currency == 'CNY') {
-        aggregatedCurrentValueCny += assetCurrentValue;
-        aggregatedNetInvestmentCny += assetNetInvestment;
-        aggregatedTotalProfitCny += assetTotalProfit;
-        hasCnyAggregation = true;
-      } else if (assetCurrentValueCny != null ||
-          assetNetInvestmentCny != null ||
-          assetTotalProfitCny != null) {
-        aggregatedCurrentValueCny += assetCurrentValueCny ?? 0.0;
-        aggregatedNetInvestmentCny += assetNetInvestmentCny ?? 0.0;
-        aggregatedTotalProfitCny += assetTotalProfitCny ?? 0.0;
-        hasCnyAggregation = true;
-      }
+      fxProfitCny = hasFxProfitCny ? aggregatedFxProfitCny : null;
     }
-
-    final double? aggregatedFxProfitCnyValue =
-        hasFxProfitCny ? aggregatedFxProfitCny : null;
-    if (assets.isNotEmpty &&
-        (account.currency == 'CNY' || aggregatedFxProfitCnyValue == null)) {
-      currentValue = aggregatedCurrentValue;
-      netInvestment = aggregatedNetInvestment;
-      totalProfit = aggregatedTotalProfit;
-      profitRate = aggregatedNetInvestment == 0
-          ? 0.0
-          : aggregatedTotalProfit / aggregatedNetInvestment;
-      if (hasCnyAggregation) {
-        currentValueCny = aggregatedCurrentValueCny;
-        netInvestmentCny = aggregatedNetInvestmentCny;
-        totalProfitCny = aggregatedTotalProfitCny;
-      }
-    }
-    fxProfitCny = aggregatedFxProfitCnyValue;
 
     return {
       'currentValue': currentValue,
@@ -1007,6 +942,7 @@ class CalculatorService {
     final fx = ExchangeRateService();
     double totalValueCNY = 0;
     double totalNetInvestmentCNY = 0;
+    double totalInvestedCNY = 0;
     double totalFxProfitCNY = 0;
     final globalCashflows = <double>[];
     final globalDates = <DateTime>[];
@@ -1018,6 +954,7 @@ class CalculatorService {
       final currentValueCNY = accValue * rate;
 
       double recordedNetInvestmentCNY = 0;
+      double recordedInvestedCNY = 0;
       double recordedCashflowProfitCNY = 0;
 
       if (account.supabaseId != null) {
@@ -1031,6 +968,7 @@ class CalculatorService {
           final amountCNY = txn.baseAmountCny ?? txn.amount * txnRate;
           if (txn.type == TransactionType.invest) {
             recordedNetInvestmentCNY += amountCNY;
+            recordedInvestedCNY += amountCNY;
             globalCashflows.add(-amountCNY);
             globalDates.add(txn.date);
           } else if (txn.type == TransactionType.withdraw) {
@@ -1044,6 +982,9 @@ class CalculatorService {
       // 如果没有记录汇率，使用当前汇率保证净值不为0
       if (recordedNetInvestmentCNY == 0 && accNetInv != 0) {
         recordedNetInvestmentCNY = accNetInv * rate;
+      }
+      if (recordedInvestedCNY == 0 && accNetInv > 0) {
+        recordedInvestedCNY = accNetInv * rate;
       }
 
       final perfValueCny = performance['currentValueCny'] as double?;
@@ -1059,6 +1000,7 @@ class CalculatorService {
 
       totalValueCNY += resolvedValueCny;
       totalNetInvestmentCNY += resolvedNetInvestmentCny;
+      totalInvestedCNY += recordedInvestedCNY;
 
       if (perfFxProfitCny != null) {
         totalFxProfitCNY += perfFxProfitCny;
@@ -1070,7 +1012,7 @@ class CalculatorService {
     }
     final double totalProfit = totalValueCNY - totalNetInvestmentCNY;
     final double totalProfitRate =
-        totalNetInvestmentCNY == 0 ? 0 : totalProfit / totalNetInvestmentCNY;
+        totalInvestedCNY == 0 ? 0 : totalProfit / totalInvestedCNY;
     double globalAnnualizedReturn = 0.0;
     if (globalCashflows.isNotEmpty && totalValueCNY != 0) {
       globalCashflows.add(totalValueCNY);

--- a/lib/services/calculator_service.dart
+++ b/lib/services/calculator_service.dart
@@ -102,15 +102,19 @@ class CalculatorService {
         .accountSupabaseIdEqualTo(account.supabaseId)
         .sortByDate()
         .findAll();
+    final assets = await _isar.assets
+        .filter()
+        .accountSupabaseIdEqualTo(account.supabaseId)
+        .findAll();
     final historyPoints = _buildAccountHistoryPoints(originalTransactions);
     if (historyPoints.isEmpty) {
       return {'currentValue': 0.0, 'netInvestment': 0.0, 'totalProfit': 0.0, 'profitRate': 0.0, 'annualizedReturn': 0.0};
     }
-    final double currentValue = historyPoints.last.value;
-    final double netInvestment = historyPoints.last.netInvestment;
+    double currentValue = historyPoints.last.value;
+    double netInvestment = historyPoints.last.netInvestment;
     final double totalInvested = historyPoints.last.totalInvested;
-    final double totalProfit = currentValue - netInvestment;
-    final double profitRate = totalInvested == 0 ? 0 : totalProfit / totalInvested;
+    double totalProfit = currentValue - netInvestment;
+    double profitRate = totalInvested == 0 ? 0 : totalProfit / totalInvested;
     double annualizedReturn = 0.0;
     final xirrCashflows = <double>[];
     final xirrDates = <DateTime>[];
@@ -170,6 +174,86 @@ class CalculatorService {
       fxProfitCny = totalProfitCny - baseProfitCny;
       netInvestmentCny = recordedNetInvestmentCNY;
     }
+
+    double aggregatedCurrentValue = 0.0;
+    double aggregatedNetInvestment = 0.0;
+    double aggregatedTotalProfit = 0.0;
+    double aggregatedCurrentValueCny = 0.0;
+    double aggregatedNetInvestmentCny = 0.0;
+    double aggregatedTotalProfitCny = 0.0;
+    double aggregatedFxProfitCny = 0.0;
+    bool hasFxProfitCny = false;
+    bool hasCnyAggregation = false;
+
+    for (final asset in assets) {
+      Map<String, dynamic> performance;
+      double assetCurrentValue = 0.0;
+      double assetNetInvestment = 0.0;
+      double assetTotalProfit = 0.0;
+      double? assetCurrentValueCny;
+      double? assetNetInvestmentCny;
+      double? assetTotalProfitCny;
+
+      if (asset.trackingMethod == AssetTrackingMethod.shareBased) {
+        performance = await calculateShareAssetPerformance(asset);
+        assetCurrentValue = (performance['marketValue'] ?? 0.0) as double;
+        assetNetInvestment = (performance['totalCost'] ?? 0.0) as double;
+        assetTotalProfit = (performance['totalProfit'] ?? 0.0) as double;
+        assetCurrentValueCny = performance['marketValueCny'] as double?;
+        assetNetInvestmentCny = performance['totalCostCny'] as double?;
+        assetTotalProfitCny = performance['totalProfitCny'] as double?;
+      } else {
+        performance = await calculateValueAssetPerformance(asset);
+        assetCurrentValue = (performance['currentValue'] ?? 0.0) as double;
+        assetNetInvestment = (performance['netInvestment'] ?? 0.0) as double;
+        assetTotalProfit = (performance['totalProfit'] ?? 0.0) as double;
+        assetCurrentValueCny = performance['currentValueCny'] as double?;
+        assetNetInvestmentCny = performance['netInvestmentCny'] as double?;
+        assetTotalProfitCny = performance['totalProfitCny'] as double?;
+      }
+
+      aggregatedCurrentValue += assetCurrentValue;
+      aggregatedNetInvestment += assetNetInvestment;
+      aggregatedTotalProfit += assetTotalProfit;
+
+      final assetFxProfitCny = performance['fxProfitCny'] as double?;
+      if (assetFxProfitCny != null) {
+        aggregatedFxProfitCny += assetFxProfitCny;
+        hasFxProfitCny = true;
+      }
+
+      if (asset.currency == 'CNY') {
+        aggregatedCurrentValueCny += assetCurrentValue;
+        aggregatedNetInvestmentCny += assetNetInvestment;
+        aggregatedTotalProfitCny += assetTotalProfit;
+        hasCnyAggregation = true;
+      } else if (assetCurrentValueCny != null ||
+          assetNetInvestmentCny != null ||
+          assetTotalProfitCny != null) {
+        aggregatedCurrentValueCny += assetCurrentValueCny ?? 0.0;
+        aggregatedNetInvestmentCny += assetNetInvestmentCny ?? 0.0;
+        aggregatedTotalProfitCny += assetTotalProfitCny ?? 0.0;
+        hasCnyAggregation = true;
+      }
+    }
+
+    final double? aggregatedFxProfitCnyValue =
+        hasFxProfitCny ? aggregatedFxProfitCny : null;
+    if (assets.isNotEmpty &&
+        (account.currency == 'CNY' || aggregatedFxProfitCnyValue == null)) {
+      currentValue = aggregatedCurrentValue;
+      netInvestment = aggregatedNetInvestment;
+      totalProfit = aggregatedTotalProfit;
+      profitRate = aggregatedNetInvestment == 0
+          ? 0.0
+          : aggregatedTotalProfit / aggregatedNetInvestment;
+      if (hasCnyAggregation) {
+        currentValueCny = aggregatedCurrentValueCny;
+        netInvestmentCny = aggregatedNetInvestmentCny;
+        totalProfitCny = aggregatedTotalProfitCny;
+      }
+    }
+    fxProfitCny = aggregatedFxProfitCnyValue;
 
     return {
       'currentValue': currentValue,
@@ -468,7 +552,20 @@ class CalculatorService {
   }
   
   Future<Map<String, dynamic>> calculateValueAssetPerformance(Asset asset) async {
-    if (asset.supabaseId == null) return {'currentValue': 0.0, 'netInvestment': 0.0, 'totalProfit': 0.0, 'profitRate': 0.0, 'annualizedReturn': 0.0};
+    if (asset.supabaseId == null) {
+      return {
+        'currentValue': 0.0,
+        'netInvestment': 0.0,
+        'totalProfit': 0.0,
+        'profitRate': 0.0,
+        'annualizedReturn': 0.0,
+        'currentValueCny': null,
+        'totalProfitCny': null,
+        'assetProfitCny': null,
+        'fxProfitCny': null,
+        'netInvestmentCny': null,
+      };
+    }
 
     final transactions = await _isar.transactions
         .filter()
@@ -477,7 +574,18 @@ class CalculatorService {
         .findAll();
 
     if (transactions.isEmpty) {
-      return {'currentValue': 0.0, 'netInvestment': 0.0, 'totalProfit': 0.0, 'profitRate': 0.0, 'annualizedReturn': 0.0};
+      return {
+        'currentValue': 0.0,
+        'netInvestment': 0.0,
+        'totalProfit': 0.0,
+        'profitRate': 0.0,
+        'annualizedReturn': 0.0,
+        'currentValueCny': null,
+        'totalProfitCny': null,
+        'assetProfitCny': null,
+        'fxProfitCny': null,
+        'netInvestmentCny': null,
+      };
     }
 
     double netInvestment = 0;

--- a/lib/services/calculator_service.dart
+++ b/lib/services/calculator_service.dart
@@ -1007,7 +1007,6 @@ class CalculatorService {
     final fx = ExchangeRateService();
     double totalValueCNY = 0;
     double totalNetInvestmentCNY = 0;
-    double totalInvestedCNY = 0;
     double totalFxProfitCNY = 0;
     final globalCashflows = <double>[];
     final globalDates = <DateTime>[];
@@ -1019,7 +1018,6 @@ class CalculatorService {
       final currentValueCNY = accValue * rate;
 
       double recordedNetInvestmentCNY = 0;
-      double recordedInvestedCNY = 0;
       double recordedCashflowProfitCNY = 0;
 
       if (account.supabaseId != null) {
@@ -1033,7 +1031,6 @@ class CalculatorService {
           final amountCNY = txn.baseAmountCny ?? txn.amount * txnRate;
           if (txn.type == TransactionType.invest) {
             recordedNetInvestmentCNY += amountCNY;
-            recordedInvestedCNY += amountCNY;
             globalCashflows.add(-amountCNY);
             globalDates.add(txn.date);
           } else if (txn.type == TransactionType.withdraw) {
@@ -1048,21 +1045,32 @@ class CalculatorService {
       if (recordedNetInvestmentCNY == 0 && accNetInv != 0) {
         recordedNetInvestmentCNY = accNetInv * rate;
       }
-      if (recordedInvestedCNY == 0 && accNetInv > 0) {
-        recordedInvestedCNY = accNetInv * rate;
+
+      final perfValueCny = performance['currentValueCny'] as double?;
+      final perfNetInvestmentCny = performance['netInvestmentCny'] as double?;
+      final perfTotalProfitCny = performance['totalProfitCny'] as double?;
+      final perfFxProfitCny = performance['fxProfitCny'] as double?;
+
+      final resolvedValueCny = perfValueCny ?? currentValueCNY;
+      final resolvedNetInvestmentCny =
+          perfNetInvestmentCny ?? recordedNetInvestmentCNY;
+      final resolvedTotalProfitCny =
+          perfTotalProfitCny ?? (resolvedValueCny - resolvedNetInvestmentCny);
+
+      totalValueCNY += resolvedValueCny;
+      totalNetInvestmentCNY += resolvedNetInvestmentCny;
+
+      if (perfFxProfitCny != null) {
+        totalFxProfitCNY += perfFxProfitCny;
+      } else {
+        final baseProfitCNY = (accValue - accNetInv) * rate;
+        recordedCashflowProfitCNY = resolvedTotalProfitCny - baseProfitCNY;
+        totalFxProfitCNY += recordedCashflowProfitCNY;
       }
-
-      totalValueCNY += currentValueCNY;
-      totalNetInvestmentCNY += recordedNetInvestmentCNY;
-      totalInvestedCNY += recordedInvestedCNY;
-
-      final totalProfitCNY = currentValueCNY - recordedNetInvestmentCNY;
-      final baseProfitCNY = (accValue - accNetInv) * rate;
-      recordedCashflowProfitCNY = totalProfitCNY - baseProfitCNY;
-      totalFxProfitCNY += recordedCashflowProfitCNY;
     }
     final double totalProfit = totalValueCNY - totalNetInvestmentCNY;
-    final double totalProfitRate = totalInvestedCNY == 0 ? 0 : totalProfit / totalInvestedCNY;
+    final double totalProfitRate =
+        totalNetInvestmentCNY == 0 ? 0 : totalProfit / totalNetInvestmentCNY;
     double globalAnnualizedReturn = 0.0;
     if (globalCashflows.isNotEmpty && totalValueCNY != 0) {
       globalCashflows.add(totalValueCNY);


### PR DESCRIPTION
### Motivation
- 修复账户层在多币种场景下汇率影响显示不一致的问题，通过按资产汇总得到更精确的人民币拆分（`fxProfitCny`）。
- 避免资产层与账户层返回字段不一致导致的 null 处理错误，保证展示逻辑稳定。 
- 将账户详情的人民币区块展示条件由仅检查 `account.currency != 'CNY'` 改为检查 `fxProfitCny != null`，以支持更多场景。 
- 减少在无汇率拆分数据时误用账户总值替代资产聚合结果的风险。 

### Description
- 在 `CalculatorService.calculateAccountPerformance` 中增加按账户下资产列表（按 `accountSupabaseId`）读取并分别调用 `calculateValueAssetPerformance` / `calculateShareAssetPerformance`，对资产层结果进行聚合并汇总 `fxProfitCny`。 
- 当存在资产聚合且账户币种为 `CNY` 或没有可用的 `fxProfitCny` 时，优先使用资产聚合结果作为展示字段（替换原基于账户 updateValue 的结果）。
- 在 `calculateValueAssetPerformance` 中补齐并统一返回的 CNY 相关 key（如 `currentValueCny`、`totalProfitCny`、`assetProfitCny`、`fxProfitCny`、`netInvestmentCny`）以避免上层空值处理异常。  
- 在 `lib/pages/account_detail_page.dart` 的 `_buildMacroView` 中将人民币区块显示条件改为 `fxProfitCny != null`，并对 `totalProfitCny` 的空值展示与颜色判断做了保护处理。 
- 数据兼容/升级提示：此 PR 仅调整服务层返回的性能聚合逻辑与返回 map 中新增/规范化的 key；建议在发布前备份本地 Isar 数据文件（例如导出或复制 db 文件），因为虽然未更改持久化模型 schema，但上层展示依赖新增字段，备份可以在回滚或数据校验时使用。 

### Testing
- 未运行任何自动化测试（未请求）。
- 本次变更已在代码中添加了空值保护与默认值处理，降低运行时 NPE/异常 风险，但建议在本地构建并进行手动功能验证（账户页面、资产列表与多币种账户）后发布。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951d79505f883268481dfb0cff00cce)