### PR TITLE
feat: 在资产详情页接入网格利润重构摘要只读展示

### DIFF
--- a/lib/pages/share_asset_detail_page.dart
+++ b/lib/pages/share_asset_detail_page.dart
@@ -646,6 +646,7 @@ class _ShareAssetDetailViewState extends ConsumerState<_ShareAssetDetailView> {
               comprehensiveProfit,
               widget.asset.currency,
             ),
+            _buildGridProfitSummaryCard(context, widget.asset.id, widget.asset.currency),
 
             // (按钮区已按要求移除)
 
@@ -762,6 +763,89 @@ class _ShareAssetDetailViewState extends ConsumerState<_ShareAssetDetailView> {
     );
   }
 
+
+
+  Widget _buildGridProfitSummaryCard(
+    BuildContext context,
+    int assetId,
+    String currencyCode,
+  ) {
+    Color pnlColor(double value) {
+      if (value > 0) return Colors.red.shade400;
+      if (value < 0) return Colors.green.shade400;
+      return Theme.of(context).textTheme.bodyMedium?.color ?? Colors.grey;
+    }
+
+    final debugAsync = ref.watch(gridProfitDebugProvider(assetId));
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: debugAsync.when(
+          data: (data) {
+            final snapshots = (data['snapshots'] as List<PositionSnapshot>?) ?? const <PositionSnapshot>[];
+            if (snapshots.length < 2) {
+              return const Text(
+                '网格利润重构：快照不足',
+                style: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+              );
+            }
+
+            final result = data['result'];
+            final double cumulativeGridProfit =
+                (result?.cumulativeGridProfit ?? 0.0) as double;
+            final double costReductionPerShare =
+                (result?.costReductionPerShare ?? 0.0) as double;
+
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '网格利润重构摘要',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 12),
+                _buildMetricRow(
+                  context,
+                  '重构网格利润:',
+                  NumberFormat.currency(
+                    locale: 'zh_CN',
+                    symbol: getCurrencySymbol(currencyCode),
+                    decimalDigits: 2,
+                  ).format(cumulativeGridProfit),
+                  color: pnlColor(cumulativeGridProfit),
+                ),
+                _buildMetricRow(
+                  context,
+                  '每份额降本:',
+                  NumberFormat('#,##0.000').format(costReductionPerShare),
+                  color: pnlColor(costReductionPerShare),
+                ),
+              ],
+            );
+          },
+          loading: () => const SizedBox(
+            height: 24,
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            ),
+          ),
+          error: (e, s) => Text(
+            '网格利润重构：加载失败',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.error,
+              fontSize: 14,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 
   Widget _buildProfitStructureCard(
     BuildContext context,

--- a/lib/pages/share_asset_detail_page.dart
+++ b/lib/pages/share_asset_detail_page.dart
@@ -774,7 +774,7 @@ class _ShareAssetDetailViewState extends ConsumerState<_ShareAssetDetailView> {
     Color pnlColor(double value) {
       if (value > 0) return Colors.red.shade400;
       if (value < 0) return Colors.green.shade400;
-      return Theme.of(context).textTheme.bodyMedium?.color ?? Colors.grey;
+      return Theme.of(context).textTheme.bodyLarge?.color ?? Colors.white;
     }
 
     final debugAsync = ref.watch(gridProfitDebugProvider(assetId));

--- a/lib/pages/share_asset_detail_page.dart
+++ b/lib/pages/share_asset_detail_page.dart
@@ -7,6 +7,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:intl/intl.dart';
 import 'package:one_five_one_ten/models/account.dart';
 import 'package:one_five_one_ten/models/asset.dart';
+import 'package:one_five_one_ten/models/grid_profit_reconstruction_result.dart';
 import 'package:one_five_one_ten/models/position_snapshot.dart';
 // import 'package:one_five_one_ten/models/transaction.dart'; // (已移除)
 import 'package:one_five_one_ten/pages/snapshot_history_page.dart';
@@ -791,11 +792,9 @@ class _ShareAssetDetailViewState extends ConsumerState<_ShareAssetDetailView> {
               );
             }
 
-            final result = data['result'];
-            final double cumulativeGridProfit =
-                (result?.cumulativeGridProfit ?? 0.0) as double;
-            final double costReductionPerShare =
-                (result?.costReductionPerShare ?? 0.0) as double;
+            final result = data['result'] as GridProfitReconstructionResult;
+            final double cumulativeGridProfit = result.cumulativeGridProfit;
+            final double costReductionPerShare = result.gridCostReductionPerShare;
 
             return Column(
               crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
### Motivation
- 将已验证的 GridProfitReconstructionService 结果以最小改动方式接入现有资产详情页，提供网格利润重构的只读摘要展示。 
- 严格遵守约束：不改数据库结构、不改 Supabase/Isar/Sync、不改算法与数据结构、且不重构页面其他部分。 
- 在页面中靠近“收益结构”或“业绩概览”位置自然展示，便于用户快速了解重构结果。 

### Description
- 在 `lib/pages/share_asset_detail_page.dart` 中新增 `Widget _buildGridProfitSummaryCard` 函数，复用现有 `gridProfitDebugProvider` 读取数据并仅做只读展示。 
- 卡片展示两个字段：`重构网格利润`（金额，保留 2 位小数）和 `每份额降本`（保留 3 位小数），并沿用项目当前盈亏配色（正红、负绿）。 
- 当快照少于 2 条时显示固定提示 `网格利润重构：快照不足`，加载/错误状态有简洁反馈；卡片被插入在“收益结构”卡片之后、图表卡片之前以最小侵入方式接入页面。 
- 未新增 provider（复用 `gridProfitDebugProvider`）、未修改服务/模型/数据库/同步逻辑。 

### Testing
- 运行 `dart analyze lib/pages/share_asset_detail_page.dart` 失败，因为环境中缺少 `dart` 命令，无法完成静态分析。 
- 运行 `flutter analyze lib/pages/share_asset_detail_page.dart` 失败，因为环境中缺少 `flutter` 命令，无法完成 Flutter 分析。 
- 仅在代码层面插入并本地保存了修改，未执行构建/单元或集成测试（因分析/构建工具在当前环境不可用）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8103d380c8326b73f8576371a61bc)