### PR TITLE
feat: 添加批量快照工作台并在 Dashboard 添加入口

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -47,3 +47,8 @@ android {
 flutter {
     source = "../.."
 }
+
+
+dependencies {
+    implementation("com.google.mlkit:text-recognition-chinese:16.0.1")
+}

--- a/lib/pages/batch_snapshot_page.dart
+++ b/lib/pages/batch_snapshot_page.dart
@@ -7,6 +7,7 @@ import 'package:one_five_one_ten/models/asset.dart';
 import 'package:one_five_one_ten/models/position_snapshot.dart';
 import 'package:one_five_one_ten/models/transaction.dart';
 import 'package:one_five_one_ten/providers/global_providers.dart';
+import 'package:isar/isar.dart';
 
 class BatchSnapshotPage extends ConsumerStatefulWidget {
   const BatchSnapshotPage({super.key});
@@ -44,8 +45,13 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
 
   Future<Map<Account, List<Asset>>> _loadBatchData() async {
     final isar = ref.read(databaseServiceProvider).isar;
-    final accounts = await isar.accounts.where().sortByName().findAll();
-    final assets = await isar.assets.where().sortByName().findAll();
+// 1. 先安全地查出所有数据
+    final accounts = await isar.accounts.where().findAll();
+    final assets = await isar.assets.where().findAll();
+
+    // 2. 使用 Dart 原生在内存中进行排序（绝对不会报类型错误）
+    accounts.sort((a, b) => a.name.compareTo(b.name));
+    assets.sort((a, b) => a.name.compareTo(b.name));
 
     final activeAssets = assets.where((asset) => !asset.isArchived).toList();
     final assetsByAccountSupabaseId = <String, List<Asset>>{};
@@ -66,7 +72,8 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
       if (accountSupabaseId == null || accountSupabaseId.isEmpty) {
         continue;
       }
-      final accountAssets = assetsByAccountSupabaseId[accountSupabaseId] ?? <Asset>[];
+      final accountAssets =
+          assetsByAccountSupabaseId[accountSupabaseId] ?? <Asset>[];
       if (accountAssets.isEmpty) {
         continue;
       }
@@ -121,7 +128,9 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
       for (final entry in groupedData.entries) {
         for (final asset in entry.value) {
           final fieldMap = _draftControllers[asset.id];
-          if (fieldMap == null || asset.supabaseId == null || asset.supabaseId!.isEmpty) {
+          if (fieldMap == null ||
+              asset.supabaseId == null ||
+              asset.supabaseId!.isEmpty) {
             continue;
           }
 
@@ -129,10 +138,15 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
             final sharesController = fieldMap['shares'];
             final costController = fieldMap['cost'];
             final profitController = fieldMap['profit'];
-            final shares = sharesController == null ? null : _parseOptionalNumber(sharesController);
-            final cost = costController == null ? null : _parseOptionalNumber(costController);
-            final comprehensiveProfit =
-                profitController == null ? null : _parseOptionalNumber(profitController);
+            final shares = sharesController == null
+                ? null
+                : _parseOptionalNumber(sharesController);
+            final cost = costController == null
+                ? null
+                : _parseOptionalNumber(costController);
+            final comprehensiveProfit = profitController == null
+                ? null
+                : _parseOptionalNumber(profitController);
 
             if (shares == null && cost == null && comprehensiveProfit == null) {
               continue;
@@ -204,7 +218,8 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(savedCount > 0 ? '批量保存成功，共保存 $savedCount 条记录' : '没有可保存的输入内容'),
+          content: Text(
+              savedCount > 0 ? '批量保存成功，共保存 $savedCount 条记录' : '没有可保存的输入内容'),
         ),
       );
 

--- a/lib/pages/batch_snapshot_page.dart
+++ b/lib/pages/batch_snapshot_page.dart
@@ -43,16 +43,14 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
     super.dispose();
   }
 
-  // ★ 修复 1 & 2：安全的查询，并兼容 nullable 的 supabaseId
   Future<List<MapEntry<Account, List<Asset>>>> _loadData() async {
     final isar = DatabaseService().isar;
     final accounts = await isar.accounts.where().findAll();
-    final assets = await isar.assets.where().findAll(); // 去掉了会导致报错的 filter
+    final assets = await isar.assets.where().findAll();
 
     accounts.sort((a, b) => a.name.compareTo(b.name));
     assets.sort((a, b) => a.name.compareTo(b.name));
 
-    // 注意这里的 Map<String?, Account> 加上了问号
     final Map<String?, Account> accountMap = {
       for (var a in accounts) a.supabaseId: a,
     };
@@ -87,31 +85,42 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
     }
   }
 
-  Future<void> _handleOcrImport(List<Asset> activeAssets) async {
+  // ★ 终极双擎 OCR 导入：代码 + 名称同时匹配
+  Future<void> _handleOcrImport(List<Asset> accountAssets) async {
     try {
       final image = await _imagePicker.pickImage(source: ImageSource.gallery);
       if (image == null) return;
 
       setState(() => _isOcrProcessing = true);
 
-      final assetNames = activeAssets.map((e) => e.name).toList();
-      final ocrService = OcrParserService();
-      final results = await ocrService.parseGuojinScreenshot(
-        image.path,
-        assetNames,
-      );
+      // 构建搜索字典：Asset ID -> [资产代码, 资产名称]
+      final Map<int, List<String>> assetSearchKeys = {};
+      for (final asset in accountAssets) {
+        final keys = <String>[];
 
-      if (results.isEmpty && context.mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('未识别到匹配的资产数据，请检查截图。')));
-        return;
+        // 🚨【极度重要】🚨
+        // 如果你的数据库里，存“518850”这个代码的字段名叫 code，请把下面的 symbol 换成 code！
+        final code = asset.code?.toString().trim();
+
+        if (code != null && code.isNotEmpty) {
+          keys.add(code); // 第一优先级：匹配 6 位代码
+        }
+        keys.add(asset.name); // 第二优先级：兜底匹配名称
+        assetSearchKeys[asset.id] = keys;
       }
 
+      final ocrService = OcrParserService();
+      // 传入字典，返回直接绑死 ID 的数据！
+      final results = await ocrService.parseGuojinScreenshot(
+        image.path,
+        assetSearchKeys,
+      );
+
       int fillCount = 0;
-      for (final asset in activeAssets) {
-        final data = results[asset.name];
-        if (data != null) {
+      for (final asset in accountAssets) {
+        final data = results[asset.id];
+        // 只要数据不为空，就填进去
+        if (data != null && data.isNotEmpty) {
           if (data.containsKey('shares')) {
             _controllerFor(asset.id, 'shares').text = data['shares'].toString();
           }
@@ -126,9 +135,15 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
       }
 
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('OCR 识别完成，已自动填充 $fillCount 个资产。')),
-        );
+        if (fillCount == 0) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('未识别到匹配的资产，请确保资产已配置证券代码，或名称与截图一致。')),
+          );
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('OCR 识别完成，已成功填充 $fillCount 个资产！')),
+          );
+        }
       }
     } catch (e) {
       if (context.mounted) {
@@ -141,11 +156,7 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
     }
   }
 
-  // ★ 判断是否为份额法资产的辅助方法 (解决幻觉报错)
   bool _isShareAsset(Asset asset) {
-    // 🚨 注意：这里我假定你们是用 subType 判断的。
-    // 如果你们的代码是用 asset.type == AssetType.fund，请在这里修改！
-    // 目前默认只要不是“银行理财”或者“现金”，就当作份额法处理。
     return asset.subType == AssetSubType.mutualFund ||
         asset.subType == AssetSubType.etf ||
         asset.subType == AssetSubType.stock;
@@ -163,7 +174,6 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
           final fields = _draftControllers[asset.id];
           if (fields == null) continue;
 
-          // ★ 修复 3：调用真正的判断方法，不再使用捏造的 calculationMethod
           if (_isShareAsset(asset)) {
             final sharesText = fields['shares']?.text.trim() ?? '';
             final costText = fields['cost']?.text.trim() ?? '';
@@ -191,7 +201,6 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
               }
             }
           } else {
-            // 价值法资产处理
             final mvText = fields['marketValue']?.text.trim() ?? '';
             final flowText = fields['netFlow']?.text.trim() ?? '';
             if (mvText.isNotEmpty) {
@@ -278,10 +287,6 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
             return const Center(child: Text('没有需要录入的活跃资产。'));
           }
 
-          final List<Asset> allActiveAssets = groupedData
-              .expand((e) => e.value)
-              .toList();
-
           return Column(
             children: [
               Container(
@@ -293,23 +298,9 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
-                        '留空会跳过，价值法录入最新市值即可。',
+                        '点击各个账户右侧的“OCR”按钮，可上传截图自动填入该账户的资产。留空的资产在保存时会被自动跳过。',
                         style: Theme.of(context).textTheme.bodySmall,
                       ),
-                    ),
-                    IconButton(
-                      onPressed: _isOcrProcessing
-                          ? null
-                          : () => _handleOcrImport(allActiveAssets),
-                      icon: _isOcrProcessing
-                          ? const SizedBox(
-                              width: 20,
-                              height: 20,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                          : const Icon(Icons.add_a_photo),
-                      tooltip: '导入国金持仓截图(OCR)',
-                      color: Theme.of(context).colorScheme.primary,
                     ),
                   ],
                 ),
@@ -322,12 +313,35 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
                     final account = entry.key;
                     final assets = entry.value;
 
-                    // 使用可折叠面板
+                    // ★ 专属的账户 OCR 入口！
                     return ExpansionTile(
                       initiallyExpanded: index == 0,
-                      title: Text(
-                        account.name,
-                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      title: Row(
+                        children: [
+                          Text(
+                            account.name,
+                            style: const TextStyle(fontWeight: FontWeight.bold),
+                          ),
+                          const Spacer(),
+                          if (_isOcrProcessing)
+                            const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          else
+                            TextButton.icon(
+                              onPressed: () => _handleOcrImport(assets),
+                              icon: const Icon(
+                                Icons.document_scanner,
+                                size: 16,
+                              ),
+                              label: const Text(
+                                'OCR',
+                                style: TextStyle(fontSize: 12),
+                              ),
+                            ),
+                        ],
                       ),
                       children: assets
                           .map((asset) => _buildAssetRow(asset))
@@ -362,7 +376,6 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
   }
 
   Widget _buildAssetRow(Asset asset) {
-    // ★ 修复 4：调用真正的判断方法
     final isShare = _isShareAsset(asset);
 
     return Padding(

--- a/lib/pages/batch_snapshot_page.dart
+++ b/lib/pages/batch_snapshot_page.dart
@@ -1,0 +1,432 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:one_five_one_ten/models/account.dart';
+import 'package:one_five_one_ten/models/asset.dart';
+import 'package:one_five_one_ten/models/position_snapshot.dart';
+import 'package:one_five_one_ten/models/transaction.dart';
+import 'package:one_five_one_ten/providers/global_providers.dart';
+
+class BatchSnapshotPage extends ConsumerStatefulWidget {
+  const BatchSnapshotPage({super.key});
+
+  @override
+  ConsumerState<BatchSnapshotPage> createState() => _BatchSnapshotPageState();
+}
+
+class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
+  final Map<int, Map<String, TextEditingController>> _draftControllers = {};
+  late Future<Map<Account, List<Asset>>> _pageDataFuture;
+  DateTime _selectedDate = DateTime.now();
+  bool _isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageDataFuture = _loadBatchData();
+  }
+
+  @override
+  void dispose() {
+    for (final fieldMap in _draftControllers.values) {
+      for (final controller in fieldMap.values) {
+        controller.dispose();
+      }
+    }
+    super.dispose();
+  }
+
+  TextEditingController _controllerFor(int assetId, String field) {
+    final fieldMap = _draftControllers.putIfAbsent(assetId, () => {});
+    return fieldMap.putIfAbsent(field, () => TextEditingController());
+  }
+
+  Future<Map<Account, List<Asset>>> _loadBatchData() async {
+    final isar = ref.read(databaseServiceProvider).isar;
+    final accounts = await isar.accounts.where().sortByName().findAll();
+    final assets = await isar.assets.where().sortByName().findAll();
+
+    final activeAssets = assets.where((asset) => !asset.isArchived).toList();
+    final assetsByAccountSupabaseId = <String, List<Asset>>{};
+
+    for (final asset in activeAssets) {
+      final accountSupabaseId = asset.accountSupabaseId;
+      if (accountSupabaseId == null || accountSupabaseId.isEmpty) {
+        continue;
+      }
+      assetsByAccountSupabaseId
+          .putIfAbsent(accountSupabaseId, () => <Asset>[])
+          .add(asset);
+    }
+
+    final result = <Account, List<Asset>>{};
+    for (final account in accounts) {
+      final accountSupabaseId = account.supabaseId;
+      if (accountSupabaseId == null || accountSupabaseId.isEmpty) {
+        continue;
+      }
+      final accountAssets = assetsByAccountSupabaseId[accountSupabaseId] ?? <Asset>[];
+      if (accountAssets.isEmpty) {
+        continue;
+      }
+      accountAssets.sort((a, b) => a.name.compareTo(b.name));
+      result[account] = accountAssets;
+    }
+    return result;
+  }
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+      locale: const Locale('zh', 'CN'),
+    );
+
+    if (picked != null) {
+      setState(() {
+        _selectedDate = DateTime(
+          picked.year,
+          picked.month,
+          picked.day,
+          _selectedDate.hour,
+          _selectedDate.minute,
+          _selectedDate.second,
+        );
+      });
+    }
+  }
+
+  double? _parseOptionalNumber(TextEditingController controller) {
+    final text = controller.text.trim();
+    if (text.isEmpty) {
+      return null;
+    }
+    return double.tryParse(text);
+  }
+
+  Future<void> _saveBatch(Map<Account, List<Asset>> groupedData) async {
+    if (_isSaving) return;
+
+    setState(() {
+      _isSaving = true;
+    });
+
+    try {
+      final syncService = ref.read(syncServiceProvider);
+      int savedCount = 0;
+
+      for (final entry in groupedData.entries) {
+        for (final asset in entry.value) {
+          final fieldMap = _draftControllers[asset.id];
+          if (fieldMap == null || asset.supabaseId == null || asset.supabaseId!.isEmpty) {
+            continue;
+          }
+
+          if (asset.trackingMethod == AssetTrackingMethod.shareBased) {
+            final sharesController = fieldMap['shares'];
+            final costController = fieldMap['cost'];
+            final profitController = fieldMap['profit'];
+            final shares = sharesController == null ? null : _parseOptionalNumber(sharesController);
+            final cost = costController == null ? null : _parseOptionalNumber(costController);
+            final comprehensiveProfit =
+                profitController == null ? null : _parseOptionalNumber(profitController);
+
+            if (shares == null && cost == null && comprehensiveProfit == null) {
+              continue;
+            }
+
+            if (shares == null || cost == null) {
+              continue;
+            }
+
+            final snapshot = PositionSnapshot()
+              ..totalShares = shares
+              ..averageCost = cost
+              ..date = _selectedDate
+              ..createdAt = DateTime.now()
+              ..assetSupabaseId = asset.supabaseId
+              ..brokerComprehensiveProfit = comprehensiveProfit;
+
+            await syncService.savePositionSnapshot(snapshot);
+            savedCount++;
+            continue;
+          }
+
+          final marketValueController = fieldMap['marketValue'];
+          final netFlowController = fieldMap['netFlow'];
+          final marketValue = marketValueController == null
+              ? null
+              : _parseOptionalNumber(marketValueController);
+          final netFlow = netFlowController == null
+              ? null
+              : _parseOptionalNumber(netFlowController);
+
+          if (marketValue == null && netFlow == null) {
+            continue;
+          }
+
+          if (netFlow != null && netFlow != 0) {
+            final flowType = netFlow >= 0
+                ? TransactionType.invest
+                : TransactionType.withdraw;
+            final flowTxn = Transaction()
+              ..type = flowType
+              ..date = _selectedDate
+              ..amount = netFlow >= 0 ? -netFlow.abs() : netFlow.abs()
+              ..createdAt = DateTime.now()
+              ..assetSupabaseId = asset.supabaseId;
+            await syncService.saveTransaction(flowTxn);
+            savedCount++;
+          }
+
+          if (marketValue != null) {
+            final valueSnapshotTxn = Transaction()
+              ..type = TransactionType.updateValue
+              ..date = _selectedDate
+              ..amount = marketValue
+              ..createdAt = DateTime.now()
+              ..assetSupabaseId = asset.supabaseId;
+            await syncService.saveTransaction(valueSnapshotTxn);
+            savedCount++;
+          }
+        }
+      }
+
+      ref.invalidate(dashboardDataProvider);
+      setState(() {
+        _pageDataFuture = _loadBatchData();
+      });
+
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(savedCount > 0 ? '批量保存成功，共保存 $savedCount 条记录' : '没有可保存的输入内容'),
+        ),
+      );
+
+      if (savedCount > 0) {
+        for (final fieldMap in _draftControllers.values) {
+          for (final controller in fieldMap.values) {
+            controller.clear();
+          }
+        }
+        setState(() {});
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('批量保存失败: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSaving = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedDateText = DateFormat('yyyy-MM-dd').format(_selectedDate);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('批量快照工作台'),
+        actions: [
+          TextButton.icon(
+            onPressed: _pickDate,
+            icon: const Icon(Icons.calendar_month),
+            label: Text(selectedDateText),
+          ),
+        ],
+      ),
+      body: FutureBuilder<Map<Account, List<Asset>>>(
+        future: _pageDataFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text('加载批量快照数据失败: ${snapshot.error}'),
+              ),
+            );
+          }
+
+          final groupedData = snapshot.data ?? const <Account, List<Asset>>{};
+          if (groupedData.isEmpty) {
+            return const Center(child: Text('暂无可录入的活跃资产'));
+          }
+
+          return ListView(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 96),
+            children: [
+              Card(
+                child: ListTile(
+                  leading: const Icon(Icons.tips_and_updates_outlined),
+                  title: const Text('录入说明'),
+                  subtitle: Text(
+                    '当前快照日期：$selectedDateText\n份额法需至少填写“最新份额 + 单位成本”；价值法可填写“当前总市值”，净投入变动为可选。空白输入会自动跳过。',
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              ...groupedData.entries.map(
+                (entry) => _buildAccountSection(entry.key, entry.value),
+              ),
+            ],
+          );
+        },
+      ),
+      floatingActionButton: FutureBuilder<Map<Account, List<Asset>>>(
+        future: _pageDataFuture,
+        builder: (context, snapshot) {
+          final groupedData = snapshot.data;
+          return FloatingActionButton.extended(
+            onPressed: (_isSaving || groupedData == null)
+                ? null
+                : () => _saveBatch(groupedData),
+            icon: _isSaving
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.save_outlined),
+            label: Text(_isSaving ? '保存中...' : '批量保存'),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildAccountSection(Account account, List<Asset> assets) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              account.name,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            ...assets.map(_buildAssetRow),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAssetRow(Asset asset) {
+    final isShareBased = asset.trackingMethod == AssetTrackingMethod.shareBased;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  asset.name,
+                  style: const TextStyle(fontWeight: FontWeight.w600),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                isShareBased ? '份额法' : '价值法',
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.primary,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          isShareBased ? _buildShareFields(asset) : _buildValueFields(asset),
+          const Divider(height: 20),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildShareFields(Asset asset) {
+    return Row(
+      children: [
+        Expanded(
+          child: _buildNumberField(
+            controller: _controllerFor(asset.id, 'shares'),
+            label: '最新份额',
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: _buildNumberField(
+            controller: _controllerFor(asset.id, 'cost'),
+            label: '单位成本',
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: _buildNumberField(
+            controller: _controllerFor(asset.id, 'profit'),
+            label: '综合收益(可选)',
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildValueFields(Asset asset) {
+    return Row(
+      children: [
+        Expanded(
+          flex: 2,
+          child: _buildNumberField(
+            controller: _controllerFor(asset.id, 'marketValue'),
+            label: '当前总市值',
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: _buildNumberField(
+            controller: _controllerFor(asset.id, 'netFlow'),
+            label: '净投入变动(可选)',
+            helperText: '流入填正，流出填负',
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildNumberField({
+    required TextEditingController controller,
+    required String label,
+    String? helperText,
+  }) {
+    return TextField(
+      controller: controller,
+      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      inputFormatters: [
+        FilteringTextInputFormatter.allow(RegExp(r'^-?\d*\.?\d*')),
+      ],
+      decoration: InputDecoration(
+        labelText: label,
+        helperText: helperText,
+        isDense: true,
+        border: const OutlineInputBorder(),
+      ),
+    );
+  }
+}

--- a/lib/pages/batch_snapshot_page.dart
+++ b/lib/pages/batch_snapshot_page.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:intl/intl.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:isar/isar.dart';
 import 'package:one_five_one_ten/models/account.dart';
 import 'package:one_five_one_ten/models/asset.dart';
 import 'package:one_five_one_ten/models/position_snapshot.dart';
 import 'package:one_five_one_ten/models/transaction.dart';
+import 'package:one_five_one_ten/services/database_service.dart';
 import 'package:one_five_one_ten/providers/global_providers.dart';
-import 'package:isar/isar.dart';
+import 'package:one_five_one_ten/services/supabase_sync_service.dart';
 import 'package:one_five_one_ten/services/ocr_parser_service.dart';
 
 class BatchSnapshotPage extends ConsumerStatefulWidget {
@@ -20,27 +21,51 @@ class BatchSnapshotPage extends ConsumerStatefulWidget {
 
 class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
   final Map<int, Map<String, TextEditingController>> _draftControllers = {};
-  final ImagePicker _imagePicker = ImagePicker();
-  final OcrParserService _ocrParserService = OcrParserService();
-  late Future<Map<Account, List<Asset>>> _pageDataFuture;
   DateTime _selectedDate = DateTime.now();
-  bool _isSaving = false;
   bool _isOcrProcessing = false;
+  bool _isSaving = false;
+  late Future<List<MapEntry<Account, List<Asset>>>> _pageDataFuture;
+  final ImagePicker _imagePicker = ImagePicker();
 
   @override
   void initState() {
     super.initState();
-    _pageDataFuture = _loadBatchData();
+    _pageDataFuture = _loadData();
   }
 
   @override
   void dispose() {
-    for (final fieldMap in _draftControllers.values) {
-      for (final controller in fieldMap.values) {
+    for (var map in _draftControllers.values) {
+      for (var controller in map.values) {
         controller.dispose();
       }
     }
     super.dispose();
+  }
+
+  // ★ 修复 1 & 2：安全的查询，并兼容 nullable 的 supabaseId
+  Future<List<MapEntry<Account, List<Asset>>>> _loadData() async {
+    final isar = DatabaseService().isar;
+    final accounts = await isar.accounts.where().findAll();
+    final assets = await isar.assets.where().findAll(); // 去掉了会导致报错的 filter
+
+    accounts.sort((a, b) => a.name.compareTo(b.name));
+    assets.sort((a, b) => a.name.compareTo(b.name));
+
+    // 注意这里的 Map<String?, Account> 加上了问号
+    final Map<String?, Account> accountMap = {
+      for (var a in accounts) a.supabaseId: a,
+    };
+    final Map<Account, List<Asset>> grouped = {};
+
+    for (final asset in assets) {
+      final acc = accountMap[asset.accountSupabaseId];
+      if (acc != null) {
+        grouped.putIfAbsent(acc, () => []).add(asset);
+      }
+    }
+
+    return grouped.entries.toList();
   }
 
   TextEditingController _controllerFor(int assetId, String field) {
@@ -48,531 +73,382 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
     return fieldMap.putIfAbsent(field, () => TextEditingController());
   }
 
-  Future<Map<Account, List<Asset>>> _loadBatchData() async {
-    final isar = ref.read(databaseServiceProvider).isar;
-// 1. 先安全地查出所有数据
-    final accounts = await isar.accounts.where().findAll();
-    final assets = await isar.assets.where().findAll();
-
-    // 2. 使用 Dart 原生在内存中进行排序（绝对不会报类型错误）
-    accounts.sort((a, b) => a.name.compareTo(b.name));
-    assets.sort((a, b) => a.name.compareTo(b.name));
-
-    final activeAssets = assets.where((asset) => !asset.isArchived).toList();
-    final assetsByAccountSupabaseId = <String, List<Asset>>{};
-
-    for (final asset in activeAssets) {
-      final accountSupabaseId = asset.accountSupabaseId;
-      if (accountSupabaseId == null || accountSupabaseId.isEmpty) {
-        continue;
-      }
-      assetsByAccountSupabaseId
-          .putIfAbsent(accountSupabaseId, () => <Asset>[])
-          .add(asset);
-    }
-
-    final result = <Account, List<Asset>>{};
-    for (final account in accounts) {
-      final accountSupabaseId = account.supabaseId;
-      if (accountSupabaseId == null || accountSupabaseId.isEmpty) {
-        continue;
-      }
-      final accountAssets =
-          assetsByAccountSupabaseId[accountSupabaseId] ?? <Asset>[];
-      if (accountAssets.isEmpty) {
-        continue;
-      }
-      accountAssets.sort((a, b) => a.name.compareTo(b.name));
-      result[account] = accountAssets;
-    }
-    return result;
-  }
-
   Future<void> _pickDate() async {
     final picked = await showDatePicker(
       context: context,
       initialDate: _selectedDate,
       firstDate: DateTime(2000),
-      lastDate: DateTime(2100),
-      locale: const Locale('zh', 'CN'),
+      lastDate: DateTime.now(),
     );
-
     if (picked != null) {
       setState(() {
-        _selectedDate = DateTime(
-          picked.year,
-          picked.month,
-          picked.day,
-          _selectedDate.hour,
-          _selectedDate.minute,
-          _selectedDate.second,
-        );
+        _selectedDate = picked;
       });
     }
   }
 
-  double? _parseOptionalNumber(TextEditingController controller) {
-    final text = controller.text.trim();
-    if (text.isEmpty) {
-      return null;
-    }
-    return _sanitizeNumericText(text);
-  }
-
-  double? _sanitizeNumericText(String raw) {
-    final cleaned = raw
-        .replaceAll(',', '')
-        .replaceAll('，', '')
-        .replaceAll('%', '')
-        .replaceAll('％', '')
-        .replaceAll('¥', '')
-        .replaceAll('￥', '')
-        .replaceAll(RegExp(r'\s+'), '')
-        .replaceAll(RegExp(r'[^0-9+\-.]'), '');
-
-    if (cleaned.isEmpty ||
-        cleaned == '-' ||
-        cleaned == '+' ||
-        cleaned == '.' ||
-        cleaned == '-.' ||
-        cleaned == '+.') {
-      return null;
-    }
-    return double.tryParse(cleaned);
-  }
-
-  String _formatDetectedNumber(double value) {
-    final text = value.toStringAsFixed(6);
-    return text
-        .replaceFirst(RegExp(r'0+$'), '')
-        .replaceFirst(RegExp(r'\.$'), '');
-  }
-
-  Future<void> _handleOcrImport() async {
-    if (_isOcrProcessing) return;
-
-    setState(() {
-      _isOcrProcessing = true;
-    });
-
+  Future<void> _handleOcrImport(List<Asset> activeAssets) async {
     try {
-      final groupedData = await _pageDataFuture;
-      final shareAssets = groupedData.values
-          .expand((assets) => assets)
-          .where((asset) => asset.trackingMethod == AssetTrackingMethod.shareBased)
-          .toList();
-
-      if (shareAssets.isEmpty) {
-        if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('当前没有可供 OCR 自动填充的份额法资产')),
-        );
-        return;
-      }
-
       final image = await _imagePicker.pickImage(source: ImageSource.gallery);
-      if (image == null) {
-        return;
-      }
+      if (image == null) return;
 
-      final assetNames = shareAssets.map((asset) => asset.name).toList();
-      final parsedData = await _ocrParserService.parseGuojinScreenshot(
+      setState(() => _isOcrProcessing = true);
+
+      final assetNames = activeAssets.map((e) => e.name).toList();
+      final ocrService = OcrParserService();
+      final results = await ocrService.parseGuojinScreenshot(
         image.path,
         assetNames,
       );
 
-      int filledAssetCount = 0;
-      for (final asset in shareAssets) {
-        final matched = parsedData[asset.name];
-        if (matched == null) {
-          continue;
-        }
-
-        final shares = matched['shares'];
-        final cost = matched['cost'];
-        final profit = matched['profit'];
-        if (shares == null || cost == null) {
-          continue;
-        }
-
-        _controllerFor(asset.id, 'shares').text = _formatDetectedNumber(shares);
-        _controllerFor(asset.id, 'cost').text = _formatDetectedNumber(cost);
-        if (profit != null) {
-          _controllerFor(asset.id, 'profit').text = _formatDetectedNumber(profit);
-        }
-        filledAssetCount++;
+      if (results.isEmpty && context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('未识别到匹配的资产数据，请检查截图。')));
+        return;
       }
 
-      if (!mounted) return;
-      setState(() {});
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('OCR 识别完成，已自动填充 $filledAssetCount 个资产'),
-        ),
-      );
+      int fillCount = 0;
+      for (final asset in activeAssets) {
+        final data = results[asset.name];
+        if (data != null) {
+          if (data.containsKey('shares')) {
+            _controllerFor(asset.id, 'shares').text = data['shares'].toString();
+          }
+          if (data.containsKey('cost')) {
+            _controllerFor(asset.id, 'cost').text = data['cost'].toString();
+          }
+          if (data.containsKey('profit')) {
+            _controllerFor(asset.id, 'profit').text = data['profit'].toString();
+          }
+          fillCount++;
+        }
+      }
+
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('OCR 识别完成，已自动填充 $fillCount 个资产。')),
+        );
+      }
     } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('OCR 识别失败: $e')),
-      );
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isOcrProcessing = false;
-        });
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('OCR 识别失败: $e')));
       }
+    } finally {
+      setState(() => _isOcrProcessing = false);
     }
   }
 
-  Future<void> _saveBatch(Map<Account, List<Asset>> groupedData) async {
-    if (_isSaving) return;
+  // ★ 判断是否为份额法资产的辅助方法 (解决幻觉报错)
+  bool _isShareAsset(Asset asset) {
+    // 🚨 注意：这里我假定你们是用 subType 判断的。
+    // 如果你们的代码是用 asset.type == AssetType.fund，请在这里修改！
+    // 目前默认只要不是“银行理财”或者“现金”，就当作份额法处理。
+    return asset.subType == AssetSubType.mutualFund ||
+        asset.subType == AssetSubType.etf ||
+        asset.subType == AssetSubType.stock;
+  }
 
-    setState(() {
-      _isSaving = true;
-    });
-
+  Future<void> _saveBatch(
+    List<MapEntry<Account, List<Asset>>> groupedData,
+  ) async {
+    setState(() => _isSaving = true);
+    int savedCount = 0;
     try {
       final syncService = ref.read(syncServiceProvider);
-      int savedCount = 0;
-
-      for (final entry in groupedData.entries) {
+      for (final entry in groupedData) {
         for (final asset in entry.value) {
-          final fieldMap = _draftControllers[asset.id];
-          if (fieldMap == null ||
-              asset.supabaseId == null ||
-              asset.supabaseId!.isEmpty) {
-            continue;
-          }
+          final fields = _draftControllers[asset.id];
+          if (fields == null) continue;
 
-          if (asset.trackingMethod == AssetTrackingMethod.shareBased) {
-            final sharesController = fieldMap['shares'];
-            final costController = fieldMap['cost'];
-            final profitController = fieldMap['profit'];
-            final shares = sharesController == null
-                ? null
-                : _parseOptionalNumber(sharesController);
-<<<<<<< HEAD
-            final cost = costController == null
-                ? null
-                : _parseOptionalNumber(costController);
-=======
-            final cost =
-                costController == null ? null : _parseOptionalNumber(costController);
->>>>>>> 6885a446c963f0ca75a03970e1872dc2ea217b4e
-            final comprehensiveProfit = profitController == null
-                ? null
-                : _parseOptionalNumber(profitController);
+          // ★ 修复 3：调用真正的判断方法，不再使用捏造的 calculationMethod
+          if (_isShareAsset(asset)) {
+            final sharesText = fields['shares']?.text.trim() ?? '';
+            final costText = fields['cost']?.text.trim() ?? '';
+            final profitText = fields['profit']?.text.trim() ?? '';
 
-            if (shares == null && cost == null && comprehensiveProfit == null) {
-              continue;
+            if (sharesText.isNotEmpty && costText.isNotEmpty) {
+              final shares = double.tryParse(sharesText);
+              final cost = double.tryParse(costText);
+              final profit = double.tryParse(profitText);
+
+              if (shares != null && cost != null) {
+                final snapshot = PositionSnapshot()
+                  ..totalShares = shares
+                  ..averageCost = cost
+                  ..brokerComprehensiveProfit = profit
+                  ..date = _selectedDate
+                  ..createdAt = DateTime.now()
+                  ..assetSupabaseId = asset.supabaseId;
+
+                await syncService.savePositionSnapshot(snapshot);
+                fields['shares']?.clear();
+                fields['cost']?.clear();
+                fields['profit']?.clear();
+                savedCount++;
+              }
             }
+          } else {
+            // 价值法资产处理
+            final mvText = fields['marketValue']?.text.trim() ?? '';
+            final flowText = fields['netFlow']?.text.trim() ?? '';
+            if (mvText.isNotEmpty) {
+              final mv = double.tryParse(mvText);
+              if (mv != null) {
+                final mvTx = Transaction()
+                  ..type = TransactionType.updateValue
+                  ..amount = mv
+                  ..date = _selectedDate
+                  ..createdAt = DateTime.now()
+                  ..assetSupabaseId = asset.supabaseId;
+                await syncService.saveTransaction(mvTx);
+                fields['marketValue']?.clear();
 
-            if (shares == null || cost == null) {
-              continue;
+                if (flowText.isNotEmpty) {
+                  final flow = double.tryParse(flowText);
+                  if (flow != null && flow != 0) {
+                    final flowTx = Transaction()
+                      ..type = flow > 0
+                          ? TransactionType.invest
+                          : TransactionType.withdraw
+                      ..amount = flow.abs()
+                      ..date = _selectedDate
+                      ..createdAt = DateTime.now()
+                      ..assetSupabaseId = asset.supabaseId;
+                    await syncService.saveTransaction(flowTx);
+                  }
+                }
+                fields['netFlow']?.clear();
+                savedCount++;
+              }
             }
-
-            final snapshot = PositionSnapshot()
-              ..totalShares = shares
-              ..averageCost = cost
-              ..date = _selectedDate
-              ..createdAt = DateTime.now()
-              ..assetSupabaseId = asset.supabaseId
-              ..brokerComprehensiveProfit = comprehensiveProfit;
-
-            await syncService.savePositionSnapshot(snapshot);
-            savedCount++;
-            continue;
-          }
-
-          final marketValueController = fieldMap['marketValue'];
-          final netFlowController = fieldMap['netFlow'];
-          final marketValue = marketValueController == null
-              ? null
-              : _parseOptionalNumber(marketValueController);
-          final netFlow = netFlowController == null
-              ? null
-              : _parseOptionalNumber(netFlowController);
-
-          if (marketValue == null && netFlow == null) {
-            continue;
-          }
-
-          if (netFlow != null && netFlow != 0) {
-            final flowType =
-                netFlow >= 0 ? TransactionType.invest : TransactionType.withdraw;
-            final flowTxn = Transaction()
-              ..type = flowType
-              ..date = _selectedDate
-              ..amount = netFlow >= 0 ? -netFlow.abs() : netFlow.abs()
-              ..createdAt = DateTime.now()
-              ..assetSupabaseId = asset.supabaseId;
-            await syncService.saveTransaction(flowTxn);
-            savedCount++;
-          }
-
-          if (marketValue != null) {
-            final valueSnapshotTxn = Transaction()
-              ..type = TransactionType.updateValue
-              ..date = _selectedDate
-              ..amount = marketValue
-              ..createdAt = DateTime.now()
-              ..assetSupabaseId = asset.supabaseId;
-            await syncService.saveTransaction(valueSnapshotTxn);
-            savedCount++;
           }
         }
       }
 
       ref.invalidate(dashboardDataProvider);
-      setState(() {
-        _pageDataFuture = _loadBatchData();
-      });
-
-      if (!mounted) return;
-
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-<<<<<<< HEAD
-          content: Text(
-              savedCount > 0 ? '批量保存成功，共保存 $savedCount 条记录' : '没有可保存的输入内容'),
-=======
-          content: Text(savedCount > 0
-              ? '批量保存成功，共保存 $savedCount 条记录'
-              : '没有可保存的输入内容'),
->>>>>>> 6885a446c963f0ca75a03970e1872dc2ea217b4e
-        ),
-      );
-
-      if (savedCount > 0) {
-        for (final fieldMap in _draftControllers.values) {
-          for (final controller in fieldMap.values) {
-            controller.clear();
-          }
-        }
-        setState(() {});
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              savedCount > 0 ? '批量保存成功，共保存 $savedCount 条记录' : '没有有效的数据被保存。',
+            ),
+          ),
+        );
       }
     } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('批量保存失败: $e')),
-      );
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isSaving = false;
-        });
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('保存出错: $e')));
       }
+    } finally {
+      setState(() => _isSaving = false);
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    final selectedDateText = DateFormat('yyyy-MM-dd').format(_selectedDate);
+    final dateStr = DateFormat('yyyy-MM-dd').format(_selectedDate);
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('批量快照工作台'),
         actions: [
-          IconButton(
-            onPressed: _isOcrProcessing ? null : _handleOcrImport,
-            tooltip: '导入国金截图 OCR',
-            icon: _isOcrProcessing
-                ? const SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.document_scanner),
-          ),
           TextButton.icon(
             onPressed: _pickDate,
-            icon: const Icon(Icons.calendar_month),
-            label: Text(selectedDateText),
+            icon: const Icon(Icons.calendar_today, color: Colors.white),
+            label: Text(dateStr, style: const TextStyle(color: Colors.white)),
           ),
         ],
       ),
-      body: FutureBuilder<Map<Account, List<Asset>>>(
+      body: FutureBuilder<List<MapEntry<Account, List<Asset>>>>(
         future: _pageDataFuture,
         builder: (context, snapshot) {
-          if (snapshot.connectionState != ConnectionState.done) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
           }
           if (snapshot.hasError) {
-            return Center(
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Text('加载批量快照数据失败: ${snapshot.error}'),
-              ),
-            );
+            return Center(child: Text('加载失败: ${snapshot.error}'));
           }
-
-          final groupedData = snapshot.data ?? const <Account, List<Asset>>{};
+          final groupedData = snapshot.data ?? [];
           if (groupedData.isEmpty) {
-            return const Center(child: Text('暂无可录入的活跃资产'));
+            return const Center(child: Text('没有需要录入的活跃资产。'));
           }
 
-          return ListView(
-            padding: const EdgeInsets.fromLTRB(16, 16, 16, 96),
+          final List<Asset> allActiveAssets = groupedData
+              .expand((e) => e.value)
+              .toList();
+
+          return Column(
             children: [
-              Card(
-                child: ListTile(
-                  leading: const Icon(Icons.tips_and_updates_outlined),
-                  title: const Text('录入说明'),
-                  subtitle: Text(
-                    '当前快照日期：$selectedDateText\n份额法需至少填写“最新份额 + 单位成本”；价值法可填写“当前总市值”，净投入变动为可选。你也可以从国金证券持仓截图中 OCR 自动填充份额法资产。',
-                  ),
+              Container(
+                padding: const EdgeInsets.all(12),
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                child: Row(
+                  children: [
+                    const Icon(Icons.lightbulb_outline),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        '留空会跳过，价值法录入最新市值即可。',
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: _isOcrProcessing
+                          ? null
+                          : () => _handleOcrImport(allActiveAssets),
+                      icon: _isOcrProcessing
+                          ? const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.add_a_photo),
+                      tooltip: '导入国金持仓截图(OCR)',
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                  ],
                 ),
               ),
-              const SizedBox(height: 12),
-              ...groupedData.entries.map(
-                (entry) => _buildAccountSection(entry.key, entry.value),
+              Expanded(
+                child: ListView.builder(
+                  itemCount: groupedData.length,
+                  itemBuilder: (context, index) {
+                    final entry = groupedData[index];
+                    final account = entry.key;
+                    final assets = entry.value;
+
+                    // 使用可折叠面板
+                    return ExpansionTile(
+                      initiallyExpanded: index == 0,
+                      title: Text(
+                        account.name,
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      children: assets
+                          .map((asset) => _buildAssetRow(asset))
+                          .toList(),
+                    );
+                  },
+                ),
               ),
             ],
           );
         },
       ),
-      floatingActionButton: FutureBuilder<Map<Account, List<Asset>>>(
-        future: _pageDataFuture,
-        builder: (context, snapshot) {
-          final groupedData = snapshot.data;
-          return FloatingActionButton.extended(
-            onPressed: (_isSaving || groupedData == null)
-                ? null
-                : () => _saveBatch(groupedData),
-            icon: _isSaving
-                ? const SizedBox(
-                    width: 18,
-                    height: 18,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.save_outlined),
-            label: Text(_isSaving ? '保存中...' : '批量保存'),
-          );
-        },
-      ),
-    );
-  }
-
-  Widget _buildAccountSection(Account account, List<Asset> assets) {
-    return Card(
-      margin: const EdgeInsets.only(bottom: 12),
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              account.name,
-              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 8),
-            ...assets.map(_buildAssetRow),
-          ],
-        ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _isSaving
+            ? null
+            : () {
+                _pageDataFuture.then((data) => _saveBatch(data));
+              },
+        icon: _isSaving
+            ? const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  color: Colors.white,
+                  strokeWidth: 2,
+                ),
+              )
+            : const Icon(Icons.save),
+        label: Text(_isSaving ? '保存中...' : '批量保存'),
       ),
     );
   }
 
   Widget _buildAssetRow(Asset asset) {
-    final isShareBased = asset.trackingMethod == AssetTrackingMethod.shareBased;
+    // ★ 修复 4：调用真正的判断方法
+    final isShare = _isShareAsset(asset);
 
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 6),
+      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Expanded(
-                child: Text(
-                  asset.name,
-                  style: const TextStyle(fontWeight: FontWeight.w600),
-                ),
-              ),
-              const SizedBox(width: 8),
               Text(
-                isShareBased ? '份额法' : '价值法',
+                asset.name,
+                style: const TextStyle(fontWeight: FontWeight.w500),
+              ),
+              Text(
+                isShare ? '份额法' : '价值法',
                 style: TextStyle(
-                  color: Theme.of(context).colorScheme.primary,
-                  fontSize: 12,
+                  fontSize: 10,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
                 ),
               ),
             ],
           ),
           const SizedBox(height: 8),
-          isShareBased ? _buildShareFields(asset) : _buildValueFields(asset),
-          const Divider(height: 20),
+          if (isShare)
+            Row(
+              children: [
+                Expanded(
+                  child: _buildTextField(
+                    _controllerFor(asset.id, 'shares'),
+                    '最新份额',
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _buildTextField(
+                    _controllerFor(asset.id, 'cost'),
+                    '单位成本',
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _buildTextField(
+                    _controllerFor(asset.id, 'profit'),
+                    '综合收益(可选)',
+                  ),
+                ),
+              ],
+            )
+          else
+            Row(
+              children: [
+                Expanded(
+                  child: _buildTextField(
+                    _controllerFor(asset.id, 'marketValue'),
+                    '当前总市值',
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _buildTextField(
+                    _controllerFor(asset.id, 'netFlow'),
+                    '净投入变动(可选)',
+                  ),
+                ),
+              ],
+            ),
+          const Divider(height: 24),
         ],
       ),
     );
   }
 
-  Widget _buildShareFields(Asset asset) {
-    return Row(
-      children: [
-        Expanded(
-          child: _buildNumberField(
-            controller: _controllerFor(asset.id, 'shares'),
-            label: '最新份额',
-          ),
-        ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: _buildNumberField(
-            controller: _controllerFor(asset.id, 'cost'),
-            label: '单位成本',
-          ),
-        ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: _buildNumberField(
-            controller: _controllerFor(asset.id, 'profit'),
-            label: '综合收益(可选)',
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildValueFields(Asset asset) {
-    return Row(
-      children: [
-        Expanded(
-          flex: 2,
-          child: _buildNumberField(
-            controller: _controllerFor(asset.id, 'marketValue'),
-            label: '当前总市值',
-          ),
-        ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: _buildNumberField(
-            controller: _controllerFor(asset.id, 'netFlow'),
-            label: '净投入变动(可选)',
-            helperText: '流入填正，流出填负',
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildNumberField({
-    required TextEditingController controller,
-    required String label,
-    String? helperText,
-  }) {
+  Widget _buildTextField(TextEditingController controller, String label) {
     return TextField(
       controller: controller,
-      keyboardType: const TextInputType.numberWithOptions(decimal: true),
-      inputFormatters: [
-        FilteringTextInputFormatter.allow(RegExp(r'^-?\d*\.?\d*')),
-      ],
       decoration: InputDecoration(
         labelText: label,
-        helperText: helperText,
         isDense: true,
         border: const OutlineInputBorder(),
       ),
+      keyboardType: const TextInputType.numberWithOptions(
+        decimal: true,
+        signed: true,
+      ),
+      style: const TextStyle(fontSize: 14),
     );
   }
 }

--- a/lib/pages/batch_snapshot_page.dart
+++ b/lib/pages/batch_snapshot_page.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:intl/intl.dart';
 import 'package:one_five_one_ten/models/account.dart';
 import 'package:one_five_one_ten/models/asset.dart';
 import 'package:one_five_one_ten/models/position_snapshot.dart';
 import 'package:one_five_one_ten/models/transaction.dart';
 import 'package:one_five_one_ten/providers/global_providers.dart';
+import 'package:one_five_one_ten/services/ocr_parser_service.dart';
 
 class BatchSnapshotPage extends ConsumerStatefulWidget {
   const BatchSnapshotPage({super.key});
@@ -17,9 +19,12 @@ class BatchSnapshotPage extends ConsumerStatefulWidget {
 
 class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
   final Map<int, Map<String, TextEditingController>> _draftControllers = {};
+  final ImagePicker _imagePicker = ImagePicker();
+  final OcrParserService _ocrParserService = OcrParserService();
   late Future<Map<Account, List<Asset>>> _pageDataFuture;
   DateTime _selectedDate = DateTime.now();
   bool _isSaving = false;
+  bool _isOcrProcessing = false;
 
   @override
   void initState() {
@@ -66,7 +71,8 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
       if (accountSupabaseId == null || accountSupabaseId.isEmpty) {
         continue;
       }
-      final accountAssets = assetsByAccountSupabaseId[accountSupabaseId] ?? <Asset>[];
+      final accountAssets =
+          assetsByAccountSupabaseId[accountSupabaseId] ?? <Asset>[];
       if (accountAssets.isEmpty) {
         continue;
       }
@@ -104,7 +110,112 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
     if (text.isEmpty) {
       return null;
     }
-    return double.tryParse(text);
+    return _sanitizeNumericText(text);
+  }
+
+  double? _sanitizeNumericText(String raw) {
+    final cleaned = raw
+        .replaceAll(',', '')
+        .replaceAll('，', '')
+        .replaceAll('%', '')
+        .replaceAll('％', '')
+        .replaceAll('¥', '')
+        .replaceAll('￥', '')
+        .replaceAll(RegExp(r'\s+'), '')
+        .replaceAll(RegExp(r'[^0-9+\-.]'), '');
+
+    if (cleaned.isEmpty ||
+        cleaned == '-' ||
+        cleaned == '+' ||
+        cleaned == '.' ||
+        cleaned == '-.' ||
+        cleaned == '+.') {
+      return null;
+    }
+    return double.tryParse(cleaned);
+  }
+
+  String _formatDetectedNumber(double value) {
+    final text = value.toStringAsFixed(6);
+    return text
+        .replaceFirst(RegExp(r'0+$'), '')
+        .replaceFirst(RegExp(r'\.$'), '');
+  }
+
+  Future<void> _handleOcrImport() async {
+    if (_isOcrProcessing) return;
+
+    setState(() {
+      _isOcrProcessing = true;
+    });
+
+    try {
+      final groupedData = await _pageDataFuture;
+      final shareAssets = groupedData.values
+          .expand((assets) => assets)
+          .where((asset) => asset.trackingMethod == AssetTrackingMethod.shareBased)
+          .toList();
+
+      if (shareAssets.isEmpty) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('当前没有可供 OCR 自动填充的份额法资产')),
+        );
+        return;
+      }
+
+      final image = await _imagePicker.pickImage(source: ImageSource.gallery);
+      if (image == null) {
+        return;
+      }
+
+      final assetNames = shareAssets.map((asset) => asset.name).toList();
+      final parsedData = await _ocrParserService.parseGuojinScreenshot(
+        image.path,
+        assetNames,
+      );
+
+      int filledAssetCount = 0;
+      for (final asset in shareAssets) {
+        final matched = parsedData[asset.name];
+        if (matched == null) {
+          continue;
+        }
+
+        final shares = matched['shares'];
+        final cost = matched['cost'];
+        final profit = matched['profit'];
+        if (shares == null || cost == null) {
+          continue;
+        }
+
+        _controllerFor(asset.id, 'shares').text = _formatDetectedNumber(shares);
+        _controllerFor(asset.id, 'cost').text = _formatDetectedNumber(cost);
+        if (profit != null) {
+          _controllerFor(asset.id, 'profit').text = _formatDetectedNumber(profit);
+        }
+        filledAssetCount++;
+      }
+
+      if (!mounted) return;
+      setState(() {});
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('OCR 识别完成，已自动填充 $filledAssetCount 个资产'),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('OCR 识别失败: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isOcrProcessing = false;
+        });
+      }
+    }
   }
 
   Future<void> _saveBatch(Map<Account, List<Asset>> groupedData) async {
@@ -121,7 +232,9 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
       for (final entry in groupedData.entries) {
         for (final asset in entry.value) {
           final fieldMap = _draftControllers[asset.id];
-          if (fieldMap == null || asset.supabaseId == null || asset.supabaseId!.isEmpty) {
+          if (fieldMap == null ||
+              asset.supabaseId == null ||
+              asset.supabaseId!.isEmpty) {
             continue;
           }
 
@@ -129,10 +242,14 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
             final sharesController = fieldMap['shares'];
             final costController = fieldMap['cost'];
             final profitController = fieldMap['profit'];
-            final shares = sharesController == null ? null : _parseOptionalNumber(sharesController);
-            final cost = costController == null ? null : _parseOptionalNumber(costController);
-            final comprehensiveProfit =
-                profitController == null ? null : _parseOptionalNumber(profitController);
+            final shares = sharesController == null
+                ? null
+                : _parseOptionalNumber(sharesController);
+            final cost =
+                costController == null ? null : _parseOptionalNumber(costController);
+            final comprehensiveProfit = profitController == null
+                ? null
+                : _parseOptionalNumber(profitController);
 
             if (shares == null && cost == null && comprehensiveProfit == null) {
               continue;
@@ -169,9 +286,8 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
           }
 
           if (netFlow != null && netFlow != 0) {
-            final flowType = netFlow >= 0
-                ? TransactionType.invest
-                : TransactionType.withdraw;
+            final flowType =
+                netFlow >= 0 ? TransactionType.invest : TransactionType.withdraw;
             final flowTxn = Transaction()
               ..type = flowType
               ..date = _selectedDate
@@ -204,7 +320,9 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(savedCount > 0 ? '批量保存成功，共保存 $savedCount 条记录' : '没有可保存的输入内容'),
+          content: Text(savedCount > 0
+              ? '批量保存成功，共保存 $savedCount 条记录'
+              : '没有可保存的输入内容'),
         ),
       );
 
@@ -238,6 +356,17 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
       appBar: AppBar(
         title: const Text('批量快照工作台'),
         actions: [
+          IconButton(
+            onPressed: _isOcrProcessing ? null : _handleOcrImport,
+            tooltip: '导入国金截图 OCR',
+            icon: _isOcrProcessing
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.document_scanner),
+          ),
           TextButton.icon(
             onPressed: _pickDate,
             icon: const Icon(Icons.calendar_month),
@@ -273,7 +402,7 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
                   leading: const Icon(Icons.tips_and_updates_outlined),
                   title: const Text('录入说明'),
                   subtitle: Text(
-                    '当前快照日期：$selectedDateText\n份额法需至少填写“最新份额 + 单位成本”；价值法可填写“当前总市值”，净投入变动为可选。空白输入会自动跳过。',
+                    '当前快照日期：$selectedDateText\n份额法需至少填写“最新份额 + 单位成本”；价值法可填写“当前总市值”，净投入变动为可选。你也可以从国金证券持仓截图中 OCR 自动填充份额法资产。',
                   ),
                 ),
               ),

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -11,6 +11,7 @@ import 'package:one_five_one_ten/utils/currency_formatter.dart';
 
 // (*** 1. 导入新模块 ***)
 import 'package:one_five_one_ten/allocation/feature_flags.dart';
+import 'package:one_five_one_ten/pages/batch_snapshot_page.dart';
 // (*** 导入结束 ***)
 
 
@@ -62,6 +63,17 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
         title: const Text('概览'),
         // (*** 2. 在这里添加新按钮 ***)
         actions: [
+          IconButton(
+            tooltip: '批量快照工作台',
+            icon: const Icon(Icons.fact_check),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const BatchSnapshotPage(),
+                ),
+              );
+            },
+          ),
           if (kFeatureAllocation)
             IconButton(
               tooltip: '资产配置',

--- a/lib/services/ocr_parser_service.dart
+++ b/lib/services/ocr_parser_service.dart
@@ -1,17 +1,18 @@
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
 
 class OcrParserService {
-  Future<Map<String, Map<String, double>>> parseGuojinScreenshot(
-      String imagePath, List<String> assetNames) async {
-    // 强制使用中文语言包进行识别
+  // ★ 升级：接收 Map<资产ID, 搜索关键词列表(代码+名称)>，返回 Map<资产ID, 提取数据>
+  Future<Map<int, Map<String, double>>> parseGuojinScreenshot(
+    String imagePath,
+    Map<int, List<String>> assetSearchKeys,
+  ) async {
     final recognizer = TextRecognizer(script: TextRecognitionScript.chinese);
-    final result = <String, Map<String, double>>{};
+    final result = <int, Map<String, double>>{};
 
     try {
       final inputImage = InputImage.fromFilePath(imagePath);
       final recognizedText = await recognizer.processImage(inputImage);
 
-      // 1. 将所有识别到的文本块打散为一个个基础元素
       List<TextElement> allElements = [];
       for (final block in recognizedText.blocks) {
         for (final line in block.lines) {
@@ -21,7 +22,7 @@ class OcrParserService {
         }
       }
 
-      // 2. 按 Y 坐标聚合成行 (误差 15 像素以内的算同一行)
+      // 1. 聚合成行 (Y 坐标差值 < 15 视作同一行)
       List<List<TextElement>> rows = [];
       for (final element in allElements) {
         bool placed = false;
@@ -40,49 +41,66 @@ class OcrParserService {
         }
       }
 
-      // 3. 排序：行按 Y 排序，行内的元素按 X (从左到右) 排序
+      // 2. 排序：自上而下，自左而右
       rows.sort(
-          (a, b) => a.first.boundingBox.top.compareTo(b.first.boundingBox.top));
+        (a, b) => a.first.boundingBox.top.compareTo(b.first.boundingBox.top),
+      );
       for (final row in rows) {
         row.sort((a, b) => a.boundingBox.left.compareTo(b.boundingBox.left));
       }
 
-      // 4. 解析匹配：找到资产名称，然后取对应的列
-      for (int i = 0; i < rows.length; i++) {
-        final row = rows[i];
+      // 3. 状态机解析：用【ID】绝对锚定当前资产
+      int? currentAssetId;
+
+      for (final row in rows) {
         if (row.isEmpty) continue;
+        String originalLineText = row.map((e) => e.text).join(' ');
+        // 清除所有空格转小写，用于暴力匹配
+        String cleanLine = originalLineText.replaceAll(' ', '').toLowerCase();
 
-        final firstText = row.first.text;
+        // ★ 核心升级：遍历所有的资产的 搜索词(代码 / 名称)
+        for (final entry in assetSearchKeys.entries) {
+          final assetId = entry.key;
+          final searchWords = entry.value;
 
-        for (final assetName in assetNames) {
-          // 模糊匹配资产名
-          if (firstText.contains(assetName) || assetName.contains(firstText)) {
-            double? shares;
-            double? profit;
-            double? cost;
-
-            // 国金第一行特征：名称 | 盈亏 | 份额 | 最新价
-            if (row.length >= 3) {
-              profit = _parseDouble(row[1].text);
-              shares = _parseDouble(row[2].text);
+          bool matched = false;
+          for (final word in searchWords) {
+            final cleanWord = word.replaceAll(' ', '').toLowerCase();
+            if (cleanWord.isNotEmpty && cleanLine.contains(cleanWord)) {
+              matched = true;
+              break;
             }
+          }
 
-            // 国金第二行特征：市值 | 比例 | 可用份额 | 单位成本
-            if (i + 1 < rows.length) {
-              final nextRow = rows[i + 1];
-              if (nextRow.length >= 4) {
-                cost = _parseDouble(nextRow[3].text);
-              }
-            }
-
-            if (shares != null || cost != null || profit != null) {
-              result[assetName] = {
-                if (shares != null) 'shares': shares,
-                if (cost != null) 'cost': cost,
-                if (profit != null) 'profit': profit,
-              };
-            }
+          if (matched) {
+            currentAssetId = assetId; // 锁定 ID！
+            result.putIfAbsent(currentAssetId, () => {});
             break;
+          }
+        }
+
+        if (currentAssetId != null) {
+          // ★ 锚点 1：提取 成本 和 综合收益
+          if (originalLineText.contains('成本/现价')) {
+            final parts = originalLineText.split('成本/现价');
+            if (parts.length == 2) {
+              final profit = _parseDouble(parts[0]);
+              if (profit != null) result[currentAssetId]!['profit'] = profit;
+
+              final costStr = parts[1].trim().split('/')[0];
+              final cost = _parseDouble(costStr);
+              if (cost != null) result[currentAssetId]!['cost'] = cost;
+            }
+          }
+
+          // ★ 锚点 2：提取 最新份额
+          if (originalLineText.contains('持仓/可用')) {
+            final parts = originalLineText.split('持仓/可用');
+            if (parts.length == 2) {
+              final shareStr = parts[1].trim().split('/')[0];
+              final shares = _parseDouble(shareStr);
+              if (shares != null) result[currentAssetId]!['shares'] = shares;
+            }
           }
         }
       }
@@ -95,9 +113,12 @@ class OcrParserService {
     return result;
   }
 
-  // 数字清洗：把逗号、百分号等杂质去掉，安全转为 double
   double? _parseDouble(String text) {
-    final cleaned = text.replaceAll(RegExp(r'[^\d.-]'), '');
-    return double.tryParse(cleaned);
+    final match = RegExp(r'-?[\d,]+(\.\d+)?').firstMatch(text);
+    if (match != null) {
+      String numStr = match.group(0)!.replaceAll(',', '');
+      return double.tryParse(numStr);
+    }
+    return null;
   }
 }

--- a/lib/services/ocr_parser_service.dart
+++ b/lib/services/ocr_parser_service.dart
@@ -1,0 +1,185 @@
+import 'dart:ui';
+
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+
+class OcrParserService {
+  Future<Map<String, Map<String, double>>> parseGuojinScreenshot(
+    String imagePath,
+    List<String> assetNames,
+  ) async {
+    if (imagePath.isEmpty || assetNames.isEmpty) {
+      return {};
+    }
+
+    final recognizer = TextRecognizer(script: TextRecognitionScript.chinese);
+
+    try {
+      final inputImage = InputImage.fromFilePath(imagePath);
+      final recognizedText = await recognizer.processImage(inputImage);
+
+      final tokens = <_OcrToken>[];
+      for (final block in recognizedText.blocks) {
+        for (final line in block.lines) {
+          if (line.elements.isEmpty) {
+            final text = line.text.trim();
+            if (text.isNotEmpty) {
+              tokens.add(
+                _OcrToken(text: text, boundingBox: line.boundingBox),
+              );
+            }
+            continue;
+          }
+
+          for (final element in line.elements) {
+            final text = element.text.trim();
+            if (text.isEmpty) {
+              continue;
+            }
+            tokens.add(
+              _OcrToken(text: text, boundingBox: element.boundingBox),
+            );
+          }
+        }
+      }
+
+      if (tokens.isEmpty) {
+        return {};
+      }
+
+      final rows = _groupTokensToRows(tokens);
+      final normalizedAssetNames = {
+        for (final name in assetNames) _normalizeAssetName(name): name,
+      };
+
+      final parsed = <String, Map<String, double>>{};
+      for (int index = 0; index < rows.length; index++) {
+        final currentRow = rows[index];
+        if (currentRow.tokens.isEmpty) {
+          continue;
+        }
+
+        final firstText = currentRow.tokens.first.text;
+        final matchedAssetName =
+            _findMatchedAssetName(firstText, normalizedAssetNames);
+        if (matchedAssetName == null) {
+          continue;
+        }
+
+        final nextRow = index + 1 < rows.length ? rows[index + 1] : null;
+        final profit = currentRow.valueAt(1);
+        final shares = currentRow.valueAt(2);
+        final cost = nextRow?.valueAt(3);
+
+        if (shares == null || cost == null) {
+          continue;
+        }
+
+        parsed[matchedAssetName] = {
+          'shares': shares,
+          'cost': cost,
+          if (profit != null) 'profit': profit,
+        };
+      }
+
+      return parsed;
+    } finally {
+      await recognizer.close();
+    }
+  }
+
+  List<_OcrRow> _groupTokensToRows(List<_OcrToken> tokens) {
+    final sortedTokens = [...tokens]
+      ..sort((a, b) => a.centerY.compareTo(b.centerY));
+
+    final rows = <_OcrRow>[];
+    for (final token in sortedTokens) {
+      if (rows.isEmpty) {
+        rows.add(_OcrRow(tokens: [token]));
+        continue;
+      }
+
+      final lastRow = rows.last;
+      if ((token.centerY - lastRow.averageCenterY).abs() <= 15) {
+        lastRow.tokens.add(token);
+      } else {
+        rows.add(_OcrRow(tokens: [token]));
+      }
+    }
+
+    for (final row in rows) {
+      row.tokens.sort((a, b) => a.centerX.compareTo(b.centerX));
+    }
+
+    return rows;
+  }
+
+  String? _findMatchedAssetName(
+    String text,
+    Map<String, String> normalizedAssetNames,
+  ) {
+    final normalizedText = _normalizeAssetName(text);
+    if (normalizedText.isEmpty) {
+      return null;
+    }
+
+    if (normalizedAssetNames.containsKey(normalizedText)) {
+      return normalizedAssetNames[normalizedText];
+    }
+
+    for (final entry in normalizedAssetNames.entries) {
+      if (normalizedText.contains(entry.key) || entry.key.contains(normalizedText)) {
+        return entry.value;
+      }
+    }
+    return null;
+  }
+
+  String _normalizeAssetName(String input) {
+    return input.replaceAll(RegExp(r'\s+'), '').trim().toLowerCase();
+  }
+}
+
+class _OcrToken {
+  _OcrToken({required this.text, required this.boundingBox});
+
+  final String text;
+  final Rect boundingBox;
+
+  double get centerX => boundingBox.center.dx;
+  double get centerY => boundingBox.center.dy;
+}
+
+class _OcrRow {
+  _OcrRow({required this.tokens});
+
+  final List<_OcrToken> tokens;
+
+  double get averageCenterY {
+    if (tokens.isEmpty) return 0;
+    final sum = tokens.fold<double>(0, (prev, token) => prev + token.centerY);
+    return sum / tokens.length;
+  }
+
+  double? valueAt(int index) {
+    if (index < 0 || index >= tokens.length) {
+      return null;
+    }
+    return _parseNumber(tokens[index].text);
+  }
+
+  double? _parseNumber(String raw) {
+    final cleaned = raw
+        .replaceAll(',', '')
+        .replaceAll('%', '')
+        .replaceAll('％', '')
+        .replaceAll('¥', '')
+        .replaceAll('￥', '')
+        .replaceAll(RegExp(r'\s+'), '')
+        .replaceAll(RegExp(r'[^0-9+\-.]'), '');
+
+    if (cleaned.isEmpty || cleaned == '-' || cleaned == '+' || cleaned == '.' || cleaned == '-.' || cleaned == '+.') {
+      return null;
+    }
+    return double.tryParse(cleaned);
+  }
+}

--- a/lib/services/ocr_parser_service.dart
+++ b/lib/services/ocr_parser_service.dart
@@ -1,185 +1,103 @@
-import 'dart:ui';
-
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
 
 class OcrParserService {
   Future<Map<String, Map<String, double>>> parseGuojinScreenshot(
-    String imagePath,
-    List<String> assetNames,
-  ) async {
-    if (imagePath.isEmpty || assetNames.isEmpty) {
-      return {};
-    }
-
+      String imagePath, List<String> assetNames) async {
+    // 强制使用中文语言包进行识别
     final recognizer = TextRecognizer(script: TextRecognitionScript.chinese);
+    final result = <String, Map<String, double>>{};
 
     try {
       final inputImage = InputImage.fromFilePath(imagePath);
       final recognizedText = await recognizer.processImage(inputImage);
 
-      final tokens = <_OcrToken>[];
+      // 1. 将所有识别到的文本块打散为一个个基础元素
+      List<TextElement> allElements = [];
       for (final block in recognizedText.blocks) {
         for (final line in block.lines) {
-          if (line.elements.isEmpty) {
-            final text = line.text.trim();
-            if (text.isNotEmpty) {
-              tokens.add(
-                _OcrToken(text: text, boundingBox: line.boundingBox),
-              );
-            }
-            continue;
-          }
-
           for (final element in line.elements) {
-            final text = element.text.trim();
-            if (text.isEmpty) {
-              continue;
-            }
-            tokens.add(
-              _OcrToken(text: text, boundingBox: element.boundingBox),
-            );
+            allElements.add(element);
           }
         }
       }
 
-      if (tokens.isEmpty) {
-        return {};
+      // 2. 按 Y 坐标聚合成行 (误差 15 像素以内的算同一行)
+      List<List<TextElement>> rows = [];
+      for (final element in allElements) {
+        bool placed = false;
+        for (final row in rows) {
+          if (row.isNotEmpty) {
+            final rowY = row.first.boundingBox.top;
+            if ((element.boundingBox.top - rowY).abs() < 15) {
+              row.add(element);
+              placed = true;
+              break;
+            }
+          }
+        }
+        if (!placed) {
+          rows.add([element]);
+        }
       }
 
-      final rows = _groupTokensToRows(tokens);
-      final normalizedAssetNames = {
-        for (final name in assetNames) _normalizeAssetName(name): name,
-      };
-
-      final parsed = <String, Map<String, double>>{};
-      for (int index = 0; index < rows.length; index++) {
-        final currentRow = rows[index];
-        if (currentRow.tokens.isEmpty) {
-          continue;
-        }
-
-        final firstText = currentRow.tokens.first.text;
-        final matchedAssetName =
-            _findMatchedAssetName(firstText, normalizedAssetNames);
-        if (matchedAssetName == null) {
-          continue;
-        }
-
-        final nextRow = index + 1 < rows.length ? rows[index + 1] : null;
-        final profit = currentRow.valueAt(1);
-        final shares = currentRow.valueAt(2);
-        final cost = nextRow?.valueAt(3);
-
-        if (shares == null || cost == null) {
-          continue;
-        }
-
-        parsed[matchedAssetName] = {
-          'shares': shares,
-          'cost': cost,
-          if (profit != null) 'profit': profit,
-        };
+      // 3. 排序：行按 Y 排序，行内的元素按 X (从左到右) 排序
+      rows.sort(
+          (a, b) => a.first.boundingBox.top.compareTo(b.first.boundingBox.top));
+      for (final row in rows) {
+        row.sort((a, b) => a.boundingBox.left.compareTo(b.boundingBox.left));
       }
 
-      return parsed;
+      // 4. 解析匹配：找到资产名称，然后取对应的列
+      for (int i = 0; i < rows.length; i++) {
+        final row = rows[i];
+        if (row.isEmpty) continue;
+
+        final firstText = row.first.text;
+
+        for (final assetName in assetNames) {
+          // 模糊匹配资产名
+          if (firstText.contains(assetName) || assetName.contains(firstText)) {
+            double? shares;
+            double? profit;
+            double? cost;
+
+            // 国金第一行特征：名称 | 盈亏 | 份额 | 最新价
+            if (row.length >= 3) {
+              profit = _parseDouble(row[1].text);
+              shares = _parseDouble(row[2].text);
+            }
+
+            // 国金第二行特征：市值 | 比例 | 可用份额 | 单位成本
+            if (i + 1 < rows.length) {
+              final nextRow = rows[i + 1];
+              if (nextRow.length >= 4) {
+                cost = _parseDouble(nextRow[3].text);
+              }
+            }
+
+            if (shares != null || cost != null || profit != null) {
+              result[assetName] = {
+                if (shares != null) 'shares': shares,
+                if (cost != null) 'cost': cost,
+                if (profit != null) 'profit': profit,
+              };
+            }
+            break;
+          }
+        }
+      }
+    } catch (e) {
+      print("OCR Error: $e");
     } finally {
-      await recognizer.close();
+      recognizer.close();
     }
+
+    return result;
   }
 
-  List<_OcrRow> _groupTokensToRows(List<_OcrToken> tokens) {
-    final sortedTokens = [...tokens]
-      ..sort((a, b) => a.centerY.compareTo(b.centerY));
-
-    final rows = <_OcrRow>[];
-    for (final token in sortedTokens) {
-      if (rows.isEmpty) {
-        rows.add(_OcrRow(tokens: [token]));
-        continue;
-      }
-
-      final lastRow = rows.last;
-      if ((token.centerY - lastRow.averageCenterY).abs() <= 15) {
-        lastRow.tokens.add(token);
-      } else {
-        rows.add(_OcrRow(tokens: [token]));
-      }
-    }
-
-    for (final row in rows) {
-      row.tokens.sort((a, b) => a.centerX.compareTo(b.centerX));
-    }
-
-    return rows;
-  }
-
-  String? _findMatchedAssetName(
-    String text,
-    Map<String, String> normalizedAssetNames,
-  ) {
-    final normalizedText = _normalizeAssetName(text);
-    if (normalizedText.isEmpty) {
-      return null;
-    }
-
-    if (normalizedAssetNames.containsKey(normalizedText)) {
-      return normalizedAssetNames[normalizedText];
-    }
-
-    for (final entry in normalizedAssetNames.entries) {
-      if (normalizedText.contains(entry.key) || entry.key.contains(normalizedText)) {
-        return entry.value;
-      }
-    }
-    return null;
-  }
-
-  String _normalizeAssetName(String input) {
-    return input.replaceAll(RegExp(r'\s+'), '').trim().toLowerCase();
-  }
-}
-
-class _OcrToken {
-  _OcrToken({required this.text, required this.boundingBox});
-
-  final String text;
-  final Rect boundingBox;
-
-  double get centerX => boundingBox.center.dx;
-  double get centerY => boundingBox.center.dy;
-}
-
-class _OcrRow {
-  _OcrRow({required this.tokens});
-
-  final List<_OcrToken> tokens;
-
-  double get averageCenterY {
-    if (tokens.isEmpty) return 0;
-    final sum = tokens.fold<double>(0, (prev, token) => prev + token.centerY);
-    return sum / tokens.length;
-  }
-
-  double? valueAt(int index) {
-    if (index < 0 || index >= tokens.length) {
-      return null;
-    }
-    return _parseNumber(tokens[index].text);
-  }
-
-  double? _parseNumber(String raw) {
-    final cleaned = raw
-        .replaceAll(',', '')
-        .replaceAll('%', '')
-        .replaceAll('％', '')
-        .replaceAll('¥', '')
-        .replaceAll('￥', '')
-        .replaceAll(RegExp(r'\s+'), '')
-        .replaceAll(RegExp(r'[^0-9+\-.]'), '');
-
-    if (cleaned.isEmpty || cleaned == '-' || cleaned == '+' || cleaned == '.' || cleaned == '-.' || cleaned == '+.') {
-      return null;
-    }
+  // 数字清洗：把逗号、百分号等杂质去掉，安全转为 double
+  double? _parseDouble(String text) {
+    final cleaned = text.replaceAll(RegExp(r'[^\d.-]'), '');
     return double.tryParse(cleaned);
   }
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,11 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 #include <gtk/gtk_plugin.h>
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
   gtk
   isar_flutter_libs
   url_launcher_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import app_links
 import file_picker
+import file_selector_macos
 import isar_flutter_libs
 import shared_preferences_foundation
 import url_launcher_macos
@@ -14,6 +15,7 @@ import url_launcher_macos
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   IsarFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "IsarFlutterLibsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -305,6 +305,38 @@ packages:
       url: "https://mirrors.cloud.tencent.com/dart-pub/"
     source: hosted
     version: "8.3.7"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "2.7.0"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "0.9.3+5"
   fixnum:
     dependency: transitive
     description:
@@ -392,6 +424,22 @@ packages:
       url: "https://mirrors.cloud.tencent.com/dart-pub/"
     source: hosted
     version: "2.1.3"
+  google_mlkit_commons:
+    dependency: transitive
+    description:
+      name: google_mlkit_commons
+      sha256: "3e69fea4211727732cc385104e675ad1e40b29f12edd492ee52fa108423a6124"
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "0.11.1"
+  google_mlkit_text_recognition:
+    dependency: "direct main"
+    description:
+      name: google_mlkit_text_recognition
+      sha256: "10a8d1a64fa21efda89514f6df88bbb7885be3ae1bfb7a6d229132d802a20d22"
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "0.15.1"
   gotrue:
     dependency: transitive
     description:
@@ -456,6 +504,70 @@ packages:
       url: "https://mirrors.cloud.tencent.com/dart-pub/"
     source: hosted
     version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "784210112be18ea55f69d7076e2c656a4e24949fa9e76429fe53af0c0f4fa320"
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "1.2.1"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: eda9b91b7e266d9041084a42d605a74937d996b87083395c5e47835916a86156
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "0.8.13+14"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://mirrors.cloud.tencent.com/dart-pub/"
+    source: hosted
+    version: "0.2.2"
   intl:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
   flutter:
@@ -25,6 +25,8 @@ dependencies:
   http: ^1.2.2
   shared_preferences: ^2.3.2
   url_launcher: ^6.3.0
+  image_picker: ^1.2.1
+  google_mlkit_text_recognition: ^0.15.1
 
 
   supabase_flutter: ^2.5.3 # (或最新版本，这个版本是 Dart 3 兼容的)

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,15 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
+#include <file_selector_windows/file_selector_windows.h>
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   IsarFlutterLibsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("IsarFlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
+  file_selector_windows
   isar_flutter_libs
   url_launcher_windows
 )


### PR DESCRIPTION
### Motivation
- 提供一个 Excel 风格的统一工作台，能按账户分组对多个资产进行极速批量快照录入，减少逐一进入详情页的摩擦。 
- 复用已有快照与同步通道，保证保存逻辑与现有数据模型兼容，避免修改同步/存储结构。 
- 对于未来若需变更保存的数据结构（例如把价值法快照独立为新表），建议先备份本地 Isar 与 Supabase 数据并设计迁移脚本以保证向后兼容。 

### Description
- 新增页面 `lib/pages/batch_snapshot_page.dart`，页面初始化通过 Isar（由 `databaseServiceProvider` 提供）读取所有 Account 与未归档 Asset，并按 `accountSupabaseId` 分组渲染。 
- 使用 `Map<int, Map<String, TextEditingController>>` 管理每个 asset.id 的录入草稿，并增加全局 `selectedDate`（默认今天）与保存状态 `_isSaving`。 
- UI: Scaffold 标题为“批量快照工作台”，按 Account 渲染 Card/Section；份额法资产渲染三列紧凑输入（最新份额、单位成本、综合收益可选），价值法资产渲染当前总市值与净投入变动（可选）；所有数值输入使用 `TextInputType.numberWithOptions(decimal: true)` 并用正则限制输入格式。 
- 批量保存逻辑：遍历草稿，空白项跳过；份额法构造 `PositionSnapshot` 并通过 `ref.read(syncServiceProvider).savePositionSnapshot(...)` 保存；价值法使用 `Transaction`，将总市值写作 `TransactionType.updateValue`，净投入变动按正负分别写作 `invest/withdraw` 并调用 `saveTransaction(...)`；保存后 `ref.invalidate(dashboardDataProvider)` 刷新并提示结果，成功后清空对应草稿。 
- 在首页 `lib/pages/dashboard_page.dart` 的 AppBar actions 添加一个 `Icons.fact_check` 的入口按钮，点击跳转到 `BatchSnapshotPage`。 

### Testing
- 已在仓库内进行静态检查：`git diff --check`（通过）。
- 已提交变更：commit 信息为 `feat: add batch snapshot workspace`（成功）。
- 本地环境未安装 Flutter/Dart 工具，所以未能在本次运行中执行 `dart format` 或真实的 Flutter 构建/运行测试；在目标开发环境请执行 `dart format` 与 `flutter analyze`、并运行应用以手动/集成测试页面交互。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac2e0a95483269f0fe5f780a1dd75)