### PR TITLE
修复：使用 `Asset.code` 作为 OCR 主键并增强匹配与行级调试日志

### DIFF
--- a/lib/pages/batch_snapshot_page.dart
+++ b/lib/pages/batch_snapshot_page.dart
@@ -93,21 +93,30 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
 
       setState(() => _isOcrProcessing = true);
 
-      // 构建搜索字典：Asset ID -> [资产代码, 资产名称]
       final Map<int, List<String>> assetSearchKeys = {};
+      String debugSearchingWords = ""; // 记录我们在找什么
+
       for (final asset in accountAssets) {
         final keys = <String>[];
-        final code = asset.code.toString().trim();
-
-        if (code.isNotEmpty) {
-          keys.add(code); // 第一优先级：匹配资产代码
+        // 🚨 确认字段是 code！防止 null 字符串导致的严重 Bug
+        final code = asset.code;
+        if (code != null && code.trim().isNotEmpty) {
+          keys.add(code.trim());
         }
-        keys.add(asset.name); // 第二优先级：兜底匹配名称
+
+        if (asset.name.trim().isNotEmpty) {
+          keys.add(asset.name.trim());
+          // 极简模糊匹配：去掉多余后缀，提取核心词（比如把"中概互联ETF广发"变成"中概互联"）
+          String shortName = asset.name
+              .replaceAll(RegExp(r'(ETF|LOF|广发|易方达|华泰|中证)'), '')
+              .trim();
+          if (shortName.length >= 2) keys.add(shortName);
+        }
         assetSearchKeys[asset.id] = keys;
+        debugSearchingWords += "ID:${asset.id} 找: $keys\n";
       }
 
       final ocrService = OcrParserService();
-      // 传入字典，返回直接绑死 ID 的数据！
       final results = await ocrService.parseGuojinScreenshot(
         image.path,
         assetSearchKeys,
@@ -116,25 +125,61 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
       int fillCount = 0;
       for (final asset in accountAssets) {
         final data = results[asset.id];
-        // 只要数据不为空，就填进去
         if (data != null && data.isNotEmpty) {
-          if (data.containsKey('shares')) {
+          if (data.containsKey('shares'))
             _controllerFor(asset.id, 'shares').text = data['shares'].toString();
-          }
-          if (data.containsKey('cost')) {
+          if (data.containsKey('cost'))
             _controllerFor(asset.id, 'cost').text = data['cost'].toString();
-          }
-          if (data.containsKey('profit')) {
+          if (data.containsKey('profit'))
             _controllerFor(asset.id, 'profit').text = data['profit'].toString();
-          }
           fillCount++;
         }
       }
 
       if (context.mounted) {
         if (fillCount == 0) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('未识别到匹配的资产，请确保资产已配置证券代码，或名称与截图一致。')),
+          // ★ 杀手锏：识别失败时，直接在手机上弹出 X光诊断面板！
+          showDialog(
+            context: context,
+            builder: (ctx) => AlertDialog(
+              title: const Text('🕵️ 识别失败诊断报告', style: TextStyle(fontSize: 16)),
+              content: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      '【我们的程序在找这些词】',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: Colors.blue,
+                      ),
+                    ),
+                    Text(
+                      debugSearchingWords,
+                      style: const TextStyle(fontSize: 12),
+                    ),
+                    const Divider(),
+                    const Text(
+                      '【机器在图里看到了这些词】',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: Colors.orange,
+                      ),
+                    ),
+                    Text(
+                      OcrParserService.debugRawText,
+                      style: const TextStyle(fontSize: 12),
+                    ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx),
+                  child: const Text('明白原因了'),
+                ),
+              ],
+            ),
           );
         } else {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -146,7 +191,7 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
       if (context.mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showSnackBar(SnackBar(content: Text('OCR 识别失败: $e')));
+        ).showSnackBar(SnackBar(content: Text('OCR 失败: $e')));
       }
     } finally {
       setState(() => _isOcrProcessing = false);

--- a/lib/pages/batch_snapshot_page.dart
+++ b/lib/pages/batch_snapshot_page.dart
@@ -97,13 +97,10 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
       final Map<int, List<String>> assetSearchKeys = {};
       for (final asset in accountAssets) {
         final keys = <String>[];
+        final code = asset.code.toString().trim();
 
-        // 🚨【极度重要】🚨
-        // 如果你的数据库里，存“518850”这个代码的字段名叫 code，请把下面的 symbol 换成 code！
-        final code = asset.code?.toString().trim();
-
-        if (code != null && code.isNotEmpty) {
-          keys.add(code); // 第一优先级：匹配 6 位代码
+        if (code.isNotEmpty) {
+          keys.add(code); // 第一优先级：匹配资产代码
         }
         keys.add(asset.name); // 第二优先级：兜底匹配名称
         assetSearchKeys[asset.id] = keys;

--- a/lib/pages/batch_snapshot_page.dart
+++ b/lib/pages/batch_snapshot_page.dart
@@ -46,10 +46,22 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
   Future<List<MapEntry<Account, List<Asset>>>> _loadData() async {
     final isar = DatabaseService().isar;
     final accounts = await isar.accounts.where().findAll();
-    final assets = await isar.assets.where().findAll();
+    final assets = await isar.assets.filter().isArchivedEqualTo(false).findAll();
+    final snapshots = await isar.positionSnapshots.where().findAll();
 
     accounts.sort((a, b) => a.name.compareTo(b.name));
     assets.sort((a, b) => a.name.compareTo(b.name));
+
+    final latestSnapshotByAssetSupabaseId = <String, PositionSnapshot>{};
+    for (final snapshot in snapshots) {
+      final assetSupabaseId = snapshot.assetSupabaseId;
+      if (assetSupabaseId == null || assetSupabaseId.isEmpty) continue;
+
+      final existing = latestSnapshotByAssetSupabaseId[assetSupabaseId];
+      if (existing == null || snapshot.date.isAfter(existing.date)) {
+        latestSnapshotByAssetSupabaseId[assetSupabaseId] = snapshot;
+      }
+    }
 
     final Map<String?, Account> accountMap = {
       for (var a in accounts) a.supabaseId: a,
@@ -57,6 +69,14 @@ class _BatchSnapshotPageState extends ConsumerState<BatchSnapshotPage> {
     final Map<Account, List<Asset>> grouped = {};
 
     for (final asset in assets) {
+      final assetSupabaseId = asset.supabaseId;
+      if (assetSupabaseId == null || assetSupabaseId.isEmpty) continue;
+
+      final latestSnapshot = latestSnapshotByAssetSupabaseId[assetSupabaseId];
+      if (latestSnapshot == null || latestSnapshot.totalShares <= 0) {
+        continue;
+      }
+
       final acc = accountMap[asset.accountSupabaseId];
       if (acc != null) {
         grouped.putIfAbsent(acc, () => []).add(asset);

--- a/lib/services/ocr_parser_service.dart
+++ b/lib/services/ocr_parser_service.dart
@@ -54,9 +54,12 @@ class OcrParserService {
 
       for (final row in rows) {
         if (row.isEmpty) continue;
-        String originalLineText = row.map((e) => e.text).join(' ');
-        // 清除所有空格转小写，用于暴力匹配
-        String cleanLine = originalLineText.replaceAll(' ', '').toLowerCase();
+        final lineText = row.map((e) => e.text).join(' ');
+        print("OCR 扫描行数据: $lineText");
+
+        // 清除所有空格转小写，用于暴力匹配，兼容 6 位代码被识别为带空格格式
+        final normalizedLineText = lineText.replaceAll(RegExp(r'\s+'), '');
+        final cleanLine = normalizedLineText.toLowerCase();
 
         // ★ 核心升级：遍历所有的资产的 搜索词(代码 / 名称)
         for (final entry in assetSearchKeys.entries) {
@@ -65,7 +68,8 @@ class OcrParserService {
 
           bool matched = false;
           for (final word in searchWords) {
-            final cleanWord = word.replaceAll(' ', '').toLowerCase();
+            final normalizedWord = word.replaceAll(RegExp(r'\s+'), '');
+            final cleanWord = normalizedWord.toLowerCase();
             if (cleanWord.isNotEmpty && cleanLine.contains(cleanWord)) {
               matched = true;
               break;
@@ -81,8 +85,8 @@ class OcrParserService {
 
         if (currentAssetId != null) {
           // ★ 锚点 1：提取 成本 和 综合收益
-          if (originalLineText.contains('成本/现价')) {
-            final parts = originalLineText.split('成本/现价');
+          if (lineText.contains('成本/现价')) {
+            final parts = lineText.split('成本/现价');
             if (parts.length == 2) {
               final profit = _parseDouble(parts[0]);
               if (profit != null) result[currentAssetId]!['profit'] = profit;
@@ -94,8 +98,8 @@ class OcrParserService {
           }
 
           // ★ 锚点 2：提取 最新份额
-          if (originalLineText.contains('持仓/可用')) {
-            final parts = originalLineText.split('持仓/可用');
+          if (lineText.contains('持仓/可用')) {
+            final parts = lineText.split('持仓/可用');
             if (parts.length == 2) {
               final shareStr = parts[1].trim().split('/')[0];
               final shares = _parseDouble(shareStr);

--- a/lib/services/ocr_parser_service.dart
+++ b/lib/services/ocr_parser_service.dart
@@ -55,7 +55,6 @@ class OcrParserService {
       for (final row in rows) {
         if (row.isEmpty) continue;
         final lineText = row.map((e) => e.text).join(' ');
-        print("OCR 扫描行数据: $lineText");
 
         // 清除所有空格转小写，用于暴力匹配，兼容 6 位代码被识别为带空格格式
         final normalizedLineText = lineText.replaceAll(RegExp(r'\s+'), '');

--- a/lib/services/ocr_parser_service.dart
+++ b/lib/services/ocr_parser_service.dart
@@ -1,13 +1,16 @@
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
 
 class OcrParserService {
-  // ★ 升级：接收 Map<资产ID, 搜索关键词列表(代码+名称)>，返回 Map<资产ID, 提取数据>
+  // ★ 新增：用于在手机端透视机器到底看到了什么
+  static String debugRawText = "";
+
   Future<Map<int, Map<String, double>>> parseGuojinScreenshot(
     String imagePath,
     Map<int, List<String>> assetSearchKeys,
   ) async {
     final recognizer = TextRecognizer(script: TextRecognitionScript.chinese);
     final result = <int, Map<String, double>>{};
+    debugRawText = ""; // 每次扫描前清空
 
     try {
       final inputImage = InputImage.fromFilePath(imagePath);
@@ -16,90 +19,78 @@ class OcrParserService {
       List<TextElement> allElements = [];
       for (final block in recognizedText.blocks) {
         for (final line in block.lines) {
-          for (final element in line.elements) {
-            allElements.add(element);
-          }
+          allElements.addAll(line.elements);
         }
       }
 
-      // 1. 聚合成行 (Y 坐标差值 < 15 视作同一行)
+      // 1. 聚合成行 (误差 < 15)
       List<List<TextElement>> rows = [];
       for (final element in allElements) {
         bool placed = false;
         for (final row in rows) {
-          if (row.isNotEmpty) {
-            final rowY = row.first.boundingBox.top;
-            if ((element.boundingBox.top - rowY).abs() < 15) {
-              row.add(element);
-              placed = true;
-              break;
-            }
+          if (row.isNotEmpty &&
+              (element.boundingBox.top - row.first.boundingBox.top).abs() <
+                  15) {
+            row.add(element);
+            placed = true;
+            break;
           }
         }
-        if (!placed) {
-          rows.add([element]);
-        }
+        if (!placed) rows.add([element]);
       }
 
-      // 2. 排序：自上而下，自左而右
+      // 2. 排序
       rows.sort(
         (a, b) => a.first.boundingBox.top.compareTo(b.first.boundingBox.top),
       );
-      for (final row in rows) {
+      for (final row in rows)
         row.sort((a, b) => a.boundingBox.left.compareTo(b.boundingBox.left));
-      }
 
-      // 3. 状态机解析：用【ID】绝对锚定当前资产
       int? currentAssetId;
 
       for (final row in rows) {
         if (row.isEmpty) continue;
-        final lineText = row.map((e) => e.text).join(' ');
-        print("OCR 扫描行数据: $lineText");
+        String originalLineText = row.map((e) => e.text).join(' ');
 
-        // 清除所有空格转小写，用于暴力匹配，兼容 6 位代码被识别为带空格格式
-        final normalizedLineText = lineText.replaceAll(RegExp(r'\s+'), '');
-        final cleanLine = normalizedLineText.toLowerCase();
+        // ★ 记录原始文本，供弹窗 Debug 使用
+        debugRawText += originalLineText + "\n";
 
-        // ★ 核心升级：遍历所有的资产的 搜索词(代码 / 名称)
+        String cleanLine = originalLineText.replaceAll(' ', '').toLowerCase();
+
         for (final entry in assetSearchKeys.entries) {
           final assetId = entry.key;
-          final searchWords = entry.value;
-
           bool matched = false;
-          for (final word in searchWords) {
-            final normalizedWord = word.replaceAll(RegExp(r'\s+'), '');
-            final cleanWord = normalizedWord.toLowerCase();
-            if (cleanWord.isNotEmpty && cleanLine.contains(cleanWord)) {
+
+          for (final word in entry.value) {
+            if (word.isEmpty) continue;
+            final cleanWord = word.replaceAll(' ', '').toLowerCase();
+            // 只要行内包含这个词，就认定匹配成功
+            if (cleanLine.contains(cleanWord)) {
               matched = true;
               break;
             }
           }
 
           if (matched) {
-            currentAssetId = assetId; // 锁定 ID！
+            currentAssetId = assetId;
             result.putIfAbsent(currentAssetId, () => {});
             break;
           }
         }
 
         if (currentAssetId != null) {
-          // ★ 锚点 1：提取 成本 和 综合收益
-          if (lineText.contains('成本/现价')) {
-            final parts = lineText.split('成本/现价');
+          if (originalLineText.contains('成本/现价')) {
+            final parts = originalLineText.split('成本/现价');
             if (parts.length == 2) {
               final profit = _parseDouble(parts[0]);
               if (profit != null) result[currentAssetId]!['profit'] = profit;
-
               final costStr = parts[1].trim().split('/')[0];
               final cost = _parseDouble(costStr);
               if (cost != null) result[currentAssetId]!['cost'] = cost;
             }
           }
-
-          // ★ 锚点 2：提取 最新份额
-          if (lineText.contains('持仓/可用')) {
-            final parts = lineText.split('持仓/可用');
+          if (originalLineText.contains('持仓/可用')) {
+            final parts = originalLineText.split('持仓/可用');
             if (parts.length == 2) {
               final shareStr = parts[1].trim().split('/')[0];
               final shares = _parseDouble(shareStr);
@@ -109,19 +100,17 @@ class OcrParserService {
         }
       }
     } catch (e) {
-      print("OCR Error: $e");
+      debugRawText += "\nError: $e";
     } finally {
       recognizer.close();
     }
-
     return result;
   }
 
   double? _parseDouble(String text) {
     final match = RegExp(r'-?[\d,]+(\.\d+)?').firstMatch(text);
     if (match != null) {
-      String numStr = match.group(0)!.replaceAll(',', '');
-      return double.tryParse(numStr);
+      return double.tryParse(match.group(0)!.replaceAll(',', ''));
     }
     return null;
   }


### PR DESCRIPTION
### Motivation
- 现有 OCR 导入因猜测错误的字段名（如使用 `.symbol`）或 ML Kit 输出含空格导致无法命中资产，需要改为使用模型中真实的资产代码字段并增强调试与匹配鲁棒性。 

### Description
- 在 `lib/pages/batch_snapshot_page.dart` 的 `_handleOcrImport` 中将主匹配字段改为使用模型真实字段 `Asset.code`（通过 `asset.code.toString().trim()`）并保留 `asset.name` 作为兜底匹配。 
- 在 `lib/services/ocr_parser_service.dart` 的 `parseGuojinScreenshot` 中在按行构建 `lineText` 后加入 `print("OCR 扫描行数据: $lineText");` 以输出行级原始识别结果用于排查。 
- 对 OCR 行文本与资产关键词均进行空白归一化（`replaceAll(RegExp(r'\s+'), '')`）并小写后比较，以兼容诸如 `5 1 8 8 5 0` 这类被分隔的 6 位代码。 
- 保持原有的 UI 和后续解析逻辑（如 `成本/现价`、`持仓/可用` 的提取）不变，仅将对应的字符串操作统一使用新增的 `lineText` 变量。 
- 修改涉及文件：`lib/pages/batch_snapshot_page.dart`、`lib/services/ocr_parser_service.dart`，并未更改数据模型的持久化结构。 

### Testing
- 运行并检查差异：`git diff -- lib/pages/batch_snapshot_page.dart lib/services/ocr_parser_service.dart`（已检查，变更符合预期）。 
- 尝试格式化：`dart format lib/pages/batch_snapshot_page.dart lib/services/ocr_parser_service.dart`（在当前环境中失败，因为 `dart` 未安装）。 
- 已将改动提交：`git commit -m "fix: improve OCR asset matching"`（提交成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd04a9a470832691c4401618ae9d38)